### PR TITLE
:star: feat: add viewUrlAs tool with Docker and service updates

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -60,7 +60,7 @@ clean-%: ## Clean specific image (e.g., clean-python)
 
 # Pattern rule for running images
 run-%: ## Run image with custom command (e.g., run-python CMD="python -c 'print(1+1)'")
-	docker run --rm -it $(REGISTRY)/gbox-$*:latest $(CMD)
+	docker run --rm -it -P $(REGISTRY)/gbox-$*:latest $(CMD)
 
 # Pattern rule for testing images
 test-%: build-% ## Test image if test.sh exists (e.g., test-python)

--- a/images/python/Dockerfile
+++ b/images/python/Dockerfile
@@ -66,8 +66,17 @@ RUN uv pip install --system \
 RUN npx playwright@1.51.1 install-deps \
     && npx playwright@1.51.1 install chromium
 
-ENTRYPOINT ["/usr/bin/tini", "--"]
+# Copy pm2 config and entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]
 
 EXPOSE 3000
 
-CMD ["npx", "playwright@1.51.1", "run-server", "--port", "3000"]
+# Add health check to verify Playwright server is running
+# Waits 5s initially, checks every 10s, times out after 5s, 3 retries
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
+    CMD curl --fail http://localhost:3000 || exit 1
+
+CMD ["sleep", "infinity"]

--- a/images/python/entrypoint.sh
+++ b/images/python/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+# Start playwright server in the background
+echo "Starting Playwright server in background..."
+npx playwright@1.51.1 run-server --port 3000 --host 0.0.0.0 &
+playwright_pid=$!
+
+echo "Waiting for Playwright server on port 3000 (PID: $playwright_pid)..."
+max_wait=30 # Maximum wait time in seconds
+waited=0
+
+# Loop until port 3000 is listening or timeout
+# Use curl to check. It exits with 0 on success (2xx/3xx), non-zero otherwise.
+# --fail makes it exit non-zero for server errors (4xx/5xx).
+# --silent prevents output to stdout/stderr.
+# --head only fetches headers, faster.
+while ! curl --fail --silent --head http://localhost:3000 > /dev/null; do
+  # Check if the playwright process is still alive
+  if ! kill -0 $playwright_pid 2>/dev/null; then
+      echo "Error: Playwright server process (PID: $playwright_pid) exited prematurely." >&2
+      # Consider adding code here to show logs if playwright writes any
+      exit 1 # Exit container if the server died
+  fi
+
+  # Check for timeout
+  if [ $waited -ge $max_wait ]; then
+    echo "Error: Timeout waiting for Playwright server on port 3000." >&2
+    # Optional: Attempt to kill the background process before exiting
+    # kill $playwright_pid 2>/dev/null || true 
+    exit 1
+  fi
+  
+  sleep 1
+  waited=$((waited + 1))
+done
+
+# Execute the command passed into the entrypoint (e.g., the CMD or runtime command)
+# This becomes the main foreground process managed by tini
+exec "$@" 

--- a/manifests/docker/docker-compose.yml
+++ b/manifests/docker/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ${GBOX_HOME:-$HOME/.gbox}:/var/gbox
     environment:
       - TZ=Asia/Shanghai
+      - GBOX_BROWSER_HOST=${GBOX_BROWSER_HOST:-host.docker.internal}
       - GBOX_HOST_SHARE=${GBOX_SHARE:-$HOME/.gbox/share}
       - GBOX_SHARE=/var/gbox/share
       - GBOX_NAMESPACE=${PREFIX}${PREFIX:+-}gbox-boxes

--- a/packages/api-server/Dockerfile
+++ b/packages/api-server/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage
-FROM golang:1.23.7-alpine3.21 AS builder
+# Using Debian-based Go image for playwright.Run() compatibility
+FROM golang:1.23.7-bookworm AS builder
 
 # Build arguments for version information
 ARG VERSION=dev
@@ -14,8 +15,11 @@ WORKDIR /app
 # Copy go mod and sum files
 COPY go.mod go.sum ./
 
-# Download dependencies
+# Download Go dependencies
 RUN go mod download
+
+# Install the Playwright Go CLI tool binary
+RUN go install github.com/playwright-community/playwright-go/cmd/playwright@latest
 
 # Copy source code
 COPY . .
@@ -27,11 +31,16 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     -X ${VERSION_PKG}.CommitID=${COMMIT_ID}" \
     -o api-server ./cmd/app/main.go
 
-# Final stage
-FROM alpine:3.21
+# --- Final stage ---
+# Switch to Debian Slim for glibc compatibility needed by playwright.Run() internals
+FROM debian:bookworm-slim
 
-# Install runtime dependencies
-RUN apk add --no-cache ca-certificates tzdata
+# Install Node.js/npm (needed to RUN the playwright CLI tool for driver install) 
+# and essential runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    tzdata \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set timezone
 ENV TZ=Asia/Shanghai
@@ -42,6 +51,14 @@ WORKDIR /app
 # Copy binary from builder
 COPY --from=builder /app/api-server .
 
+# Copy the Playwright CLI tool binary built in the builder stage
+# The Go builder image typically puts binaries in /go/bin
+COPY --from=builder /go/bin/playwright /usr/local/bin/playwright
+
+# Run playwright install WITHOUT browser names to install only the drivers/Node runtime
+# This is what playwright.Run() seems to require internally
+RUN playwright install --with-deps chromium
+
 # Copy config files if any
 COPY --from=builder /app/config ./config
 
@@ -49,4 +66,5 @@ COPY --from=builder /app/config ./config
 EXPOSE 28080
 
 # Run the application
+# Playwright will auto-download its small drivers to ~/.cache/ms-playwright-go on first run
 CMD ["./api-server"] 

--- a/packages/api-server/config/config.yaml
+++ b/packages/api-server/config/config.yaml
@@ -2,6 +2,9 @@
 server:
   port: 28080
 
+browser:
+  host: "localhost"
+
 # File service configuration
 file:
   # Base directories

--- a/packages/api-server/internal/browser/service/page_action_vision_test.go
+++ b/packages/api-server/internal/browser/service/page_action_vision_test.go
@@ -1,12 +1,11 @@
 package service_test
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
-	"time"
 
 	"github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/assert"
@@ -60,398 +59,237 @@ func setupPlaywrightPage(t *testing.T) (playwright.Page, func()) {
 	return page, cleanup
 }
 
-func TestExecuteVisionScreenshot(t *testing.T) {
+// TestVisionScreenshotOptions focuses on testing the mapping of VisionScreenshotParams
+// to playwright.PageScreenshotOptions and calling Playwright directly.
+// NOTE: This does NOT test the full service logic (URL/Base64 generation, file saving in service).
+func TestVisionScreenshotOptions(t *testing.T) {
 	page, cleanup := setupPlaywrightPage(t)
 	defer cleanup()
 
-	// Get the configured share directory path from the main application config
 	cfg := config.GetInstance()
-	// Define a dummy BoxID for testing purposes, as the actual service func includes it
-	testBoxID := "test-box-id"
+	testBoxID := "test-box-options"
 	expectedBoxDefaultDir := filepath.Join(cfg.File.Share, testBoxID, "screenshot")
-
-	// Ensure the target directory exists on the host machine before running tests
 	err := os.MkdirAll(expectedBoxDefaultDir, 0755)
-	require.NoError(t, err, "Failed to create configured default screenshot directory (with boxID) on host: %s", expectedBoxDefaultDir)
+	require.NoError(t, err, "Failed to create default screenshot directory for testing: %s", expectedBoxDefaultDir)
 
-	// Define test cases
 	testCases := []struct {
 		name           string
-		params         model.VisionScreenshotParams
-		manualPath     string // Optional: Path to use instead of generating default, for inspection
-		filenamePrefix string // Optional: Prefix for default filename generation
+		params         model.VisionScreenshotParams // Use the updated params struct (no Path)
 		expectError    bool
-		expectedExt    string                                              // e.g., ".png", ".jpeg"
-		validatePath   func(t *testing.T, path string, expectedDir string) // Pass expected dir
+		outputPath     *string                                               // Explicit path for Playwright options, can be nil for buffer
+		validateOutput func(t *testing.T, outputPath *string, buffer []byte) // Validation function
 	}{
 		{
-			name:           "Default path (PNG)",
-			params:         model.VisionScreenshotParams{},
-			filenamePrefix: "screenshot_", // Standard prefix
-			expectError:    false,
-			expectedExt:    ".png",
-			validatePath: func(t *testing.T, path string, expectedDir string) {
-				assert.Equal(t, expectedDir, filepath.Dir(path), "Path should be within the configured host screenshot directory including boxID")
-				match, _ := regexp.MatchString(`^screenshot_\d{8}_\d{6}\.png$`, filepath.Base(path))
-				assert.True(t, match, "Filename should match timestamp format screenshot_YYYYMMDD_HHMMSS.png")
-			},
-		},
-		{
-			name:   "Specific path (PNG in temp dir)",
-			params: model.VisionScreenshotParams{
-				// Path will be generated inside t.Run using t.TempDir()
-			},
+			name:        "Default PNG to Buffer",
+			params:      model.VisionScreenshotParams{}, // Empty params, OutputFormat defaults to base64 in service, but here means buffer
 			expectError: false,
-			expectedExt: ".png",
-			validatePath: func(t *testing.T, path string, expectedDir string) {
-				// expectedDir will be the temp dir created in t.Run
-				assert.Equal(t, filepath.Join(expectedDir, "specific_test.png"), path, "Path should match the generated temp path")
+			outputPath:  nil, // Capture buffer
+			validateOutput: func(t *testing.T, outputPath *string, buffer []byte) {
+				assert.Nil(t, outputPath, "Output path should be nil for buffer capture")
+				assert.NotEmpty(t, buffer, "Buffer should not be empty")
+				// Basic PNG check (first few bytes)
+				assert.True(t, len(buffer) > 8 && string(buffer[:8]) == "\x89PNG\r\n\x1a\n", "Buffer should start with PNG signature")
+				// Can optionally decode base64 if comparing with service output
+				encoded := base64.StdEncoding.EncodeToString(buffer)
+				assert.NotEmpty(t, encoded)
 			},
 		},
 		{
-			name: "Default path (JPEG)",
+			name: "JPEG with Quality to Buffer",
 			params: model.VisionScreenshotParams{
 				Type:    playwright.String("jpeg"),
 				Quality: playwright.Int(80),
 			},
-			filenamePrefix: "screenshot_", // Standard prefix
-			expectError:    false,
-			expectedExt:    ".jpeg",
-			validatePath: func(t *testing.T, path string, expectedDir string) {
-				assert.Equal(t, expectedDir, filepath.Dir(path), "Path should be within the configured host screenshot directory including boxID")
-				match, _ := regexp.MatchString(`^screenshot_\d{8}_\d{6}\.jpeg$`, filepath.Base(path))
-				assert.True(t, match, "Filename should match timestamp format screenshot_YYYYMMDD_HHMMSS.jpeg")
+			expectError: false,
+			outputPath:  nil, // Capture buffer
+			validateOutput: func(t *testing.T, outputPath *string, buffer []byte) {
+				assert.Nil(t, outputPath, "Output path should be nil for buffer capture")
+				assert.NotEmpty(t, buffer, "Buffer should not be empty")
+				// Basic JPEG check (first few bytes)
+				assert.True(t, len(buffer) > 2 && string(buffer[:2]) == "\xff\xd8", "Buffer should start with JPEG SOI marker")
 			},
 		},
 		{
-			name: "Specific path (JPEG with Quality in temp dir)",
+			name:   "Save PNG to Specific Path",
 			params: model.VisionScreenshotParams{
-				// Path will be generated inside t.Run using t.TempDir()
+				// Type defaults to PNG
+			},
+			expectError: false,
+			outputPath:  func() *string { p := filepath.Join(t.TempDir(), "test_save.png"); return &p }(),
+			validateOutput: func(t *testing.T, outputPath *string, buffer []byte) {
+				require.NotNil(t, outputPath, "Output path should be provided")
+				_, err := os.Stat(*outputPath)
+				assert.NoError(t, err, "File should exist at the specified path: %s", *outputPath)
+				assert.Equal(t, ".png", filepath.Ext(*outputPath), "File extension should be .png")
+			},
+		},
+		{
+			name: "Save JPEG to Specific Path",
+			params: model.VisionScreenshotParams{
 				Type:    playwright.String("jpeg"),
 				Quality: playwright.Int(90),
 			},
 			expectError: false,
-			expectedExt: ".jpeg",
-			validatePath: func(t *testing.T, path string, expectedDir string) {
-				// expectedDir will be the temp dir created in t.Run
-				assert.Equal(t, filepath.Join(expectedDir, "specific_test_quality.jpeg"), path, "Path should match the generated temp path")
+			outputPath:  func() *string { p := filepath.Join(t.TempDir(), "test_save.jpeg"); return &p }(),
+			validateOutput: func(t *testing.T, outputPath *string, buffer []byte) {
+				require.NotNil(t, outputPath, "Output path should be provided")
+				_, err := os.Stat(*outputPath)
+				assert.NoError(t, err, "File should exist at the specified path: %s", *outputPath)
+				assert.Equal(t, ".jpeg", filepath.Ext(*outputPath), "File extension should be .jpeg")
 			},
 		},
 		{
-			name: "Full page screenshot (in default dir)", // Updated name
+			name: "Full Page PNG to Buffer",
 			params: model.VisionScreenshotParams{
-				// Path generated manually below
 				FullPage: playwright.Bool(true),
 			},
-			filenamePrefix: "screenshot_fullpage_", // Custom prefix
-			expectError:    false,
-			expectedExt:    ".png",
-			validatePath: func(t *testing.T, path string, expectedDir string) {
-				assert.Equal(t, expectedDir, filepath.Dir(path), "Path should be within the configured host screenshot directory including boxID")
-				match, _ := regexp.MatchString(`^screenshot_fullpage_\d{8}_\d{6}\.png$`, filepath.Base(path))
-				assert.True(t, match, "Filename should match prefix and timestamp")
+			expectError: false,
+			outputPath:  nil,
+			validateOutput: func(t *testing.T, outputPath *string, buffer []byte) {
+				assert.Nil(t, outputPath)
+				assert.NotEmpty(t, buffer)
+				assert.True(t, len(buffer) > 8 && string(buffer[:8]) == "\x89PNG\r\n\x1a\n")
+				// Note: Validating *if* it's truly full page requires comparison or more complex analysis
 			},
 		},
 		{
-			name: "Clip screenshot (in temp dir)", // Keep clip in temp dir for now
+			name: "Clip PNG to Buffer",
 			params: model.VisionScreenshotParams{
-				// Path will be generated inside t.Run using t.TempDir()
 				Clip: &model.Rect{X: 10, Y: 10, Width: 50, Height: 50},
 			},
 			expectError: false,
-			expectedExt: ".png",
-			validatePath: func(t *testing.T, path string, expectedDir string) {
-				// expectedDir will be the temp dir created in t.Run
-				assert.Equal(t, filepath.Join(expectedDir, "clipped.png"), path, "Path should match the generated temp path")
+			outputPath:  nil,
+			validateOutput: func(t *testing.T, outputPath *string, buffer []byte) {
+				assert.Nil(t, outputPath)
+				assert.NotEmpty(t, buffer)
+				assert.True(t, len(buffer) > 8 && string(buffer[:8]) == "\x89PNG\r\n\x1a\n")
+				// Note: Validating clip dimensions requires image analysis
 			},
 		},
 		{
-			name: "Invalid Path (Directory as file)",
+			name:   "Invalid Path (Directory as file)",
 			params: model.VisionScreenshotParams{
-				// Create a specific temp dir for this test and pass its path
-				Path: func() *string { dir := t.TempDir(); return &dir }(),
+				// No specific params needed, path is set directly in outputPath
 			},
-			expectError:  true,
-			expectedExt:  "",
-			validatePath: nil,
+			expectError:    true,
+			outputPath:     func() *string { dir := t.TempDir(); return &dir }(), // Use the temp dir itself as path
+			validateOutput: nil,                                                  // No output to validate on error
 		},
-		// --- Test Cases for Other Options (Saving to Default Dir) ---
+		// Add more cases for other options like OmitBackground, Scale, Animations, Caret, Timeout
+		// Example for OmitBackground to Buffer:
 		{
-			name: "Omit background (PNG in default dir)",
+			name: "Omit Background PNG to Buffer",
 			params: model.VisionScreenshotParams{
 				OmitBackground: playwright.Bool(true),
 			},
-			filenamePrefix: "screenshot_omitbg_",
-			expectError:    false,
-			expectedExt:    ".png",
-			validatePath: func(t *testing.T, path string, expectedDir string) {
-				assert.Equal(t, expectedDir, filepath.Dir(path), "Path should be within the configured host screenshot directory including boxID")
-				match, _ := regexp.MatchString(`^screenshot_omitbg_\d{8}_\d{6}\.png$`, filepath.Base(path))
-				assert.True(t, match, "Filename should match prefix and timestamp")
-				// Visual inspection needed
-			},
-		},
-		{
-			name: "Scale CSS (in default dir)",
-			params: model.VisionScreenshotParams{
-				Scale: playwright.String("css"),
-			},
-			filenamePrefix: "screenshot_scalecss_",
-			expectError:    false,
-			expectedExt:    ".png",
-			validatePath: func(t *testing.T, path string, expectedDir string) {
-				assert.Equal(t, expectedDir, filepath.Dir(path), "Path should be within the configured host screenshot directory including boxID")
-				match, _ := regexp.MatchString(`^screenshot_scalecss_\d{8}_\d{6}\.png$`, filepath.Base(path))
-				assert.True(t, match, "Filename should match prefix and timestamp")
-				// Visual inspection needed
-			},
-		},
-		{
-			name: "Animations disabled (in default dir)",
-			params: model.VisionScreenshotParams{
-				Animations: playwright.String("disabled"),
-			},
-			filenamePrefix: "screenshot_animdisabled_",
-			expectError:    false,
-			expectedExt:    ".png",
-			validatePath: func(t *testing.T, path string, expectedDir string) {
-				assert.Equal(t, expectedDir, filepath.Dir(path), "Path should be within the configured host screenshot directory including boxID")
-				match, _ := regexp.MatchString(`^screenshot_animdisabled_\d{8}_\d{6}\.png$`, filepath.Base(path))
-				assert.True(t, match, "Filename should match prefix and timestamp")
-			},
-		},
-		{
-			name: "Caret initial (in default dir)",
-			params: model.VisionScreenshotParams{
-				Caret: playwright.String("initial"),
-			},
-			filenamePrefix: "screenshot_caretinitial_",
-			expectError:    false,
-			expectedExt:    ".png",
-			validatePath: func(t *testing.T, path string, expectedDir string) {
-				assert.Equal(t, expectedDir, filepath.Dir(path), "Path should be within the configured host screenshot directory including boxID")
-				match, _ := regexp.MatchString(`^screenshot_caretinitial_\d{8}_\d{6}\.png$`, filepath.Base(path))
-				assert.True(t, match, "Filename should match prefix and timestamp")
-			},
-		},
-		{
-			name: "Low Timeout (in default dir)",
-			params: model.VisionScreenshotParams{
-				Timeout: playwright.Float(500), // 500 ms timeout
-			},
-			filenamePrefix: "screenshot_timeout_",
-			expectError:    false, // Might fail depending on page load speed
-			expectedExt:    ".png",
-			validatePath: func(t *testing.T, path string, expectedDir string) {
-				assert.Equal(t, expectedDir, filepath.Dir(path), "Path should be within the configured host screenshot directory including boxID")
-				match, _ := regexp.MatchString(`^screenshot_timeout_\d{8}_\d{6}\.png$`, filepath.Base(path))
-				assert.True(t, match, "Filename should match prefix and timestamp")
-			},
-		},
-		{
-			name: "Combined Options (JPEG in default dir)",
-			params: model.VisionScreenshotParams{
-				Type:           playwright.String("jpeg"),
-				Quality:        playwright.Int(60),
-				OmitBackground: playwright.Bool(true),
-				Scale:          playwright.String("css"),
-				Animations:     playwright.String("disabled"),
-			},
-			filenamePrefix: "screenshot_combined_",
-			expectError:    false,
-			expectedExt:    ".jpeg",
-			validatePath: func(t *testing.T, path string, expectedDir string) {
-				assert.Equal(t, expectedDir, filepath.Dir(path), "Path should be within the configured host screenshot directory including boxID")
-				match, _ := regexp.MatchString(`^screenshot_combined_\d{8}_\d{6}\.jpeg$`, filepath.Base(path))
-				assert.True(t, match, "Filename should match prefix and timestamp")
-			},
-		},
-		// --- Test Relative Path ---
-		{
-			name: "Relative path (PNG in default subdir)",
-			params: model.VisionScreenshotParams{
-				Path: playwright.String("subdir/relative_test.png"), // Provide relative path
-			},
-			// No filenamePrefix needed, path is explicitly set
 			expectError: false,
-			expectedExt: ".png",
-			validatePath: func(t *testing.T, path string, expectedBaseDir string) {
-				// expectedBaseDir passed here will be expectedBoxDefaultDir
-				expectedFullPath := filepath.Join(expectedBaseDir, "subdir/relative_test.png")
-				assert.Equal(t, expectedFullPath, path, "Path should match base dir + relative path")
-				// Also check the directory part matches the base dir + subdir
-				assert.Equal(t, filepath.Join(expectedBaseDir, "subdir"), filepath.Dir(path), "Directory should be box base dir + subdir")
+			outputPath:  nil,
+			validateOutput: func(t *testing.T, outputPath *string, buffer []byte) {
+				assert.Nil(t, outputPath)
+				assert.NotEmpty(t, buffer)
+				// Visual inspection or advanced image analysis needed to confirm transparency
 			},
 		},
 	}
 
 	for _, tc := range testCases {
-		// --- Prepare Path and Options ---
-		var finalSavePath string
-		var isTempPath bool = false // Flag to indicate if path is temporary
-
-		// Special handling for temp paths inside t.Run
-		if tc.name == "Specific path (PNG in temp dir)" ||
-			tc.name == "Specific path (JPEG with Quality in temp dir)" ||
-			tc.name == "Clip screenshot (in temp dir)" {
-			isTempPath = true
-			// Path generation will happen inside t.Run
-		} else if tc.filenamePrefix != "" {
-			// Generate path based on prefix and default dir
-			timestamp := time.Now().Format("20060102_150405")
-			fileExt := tc.expectedExt
-			if fileExt == "" {
-				fileExt = ".png"
-			}
-			if tc.params.Type != nil && (*tc.params.Type == "jpeg" || *tc.params.Type == "jpg") {
-				fileExt = ".jpeg"
-			}
-			if fileExt[0] != '.' {
-				fileExt = "." + fileExt
-			}
-			filename := fmt.Sprintf("%s%s%s", tc.filenamePrefix, timestamp, fileExt)
-			finalSavePath = filepath.Join(expectedBoxDefaultDir, filename)
-			t.Logf("Test case '%s' will save to explicit path: %s", tc.name, finalSavePath)
-		} else if tc.params.Path != nil {
-			// If path is explicitly provided in params (e.g., relative path)
-			// Handle relative vs absolute provided path
-			if filepath.IsAbs(*tc.params.Path) {
-				finalSavePath = *tc.params.Path // Use absolute path directly (e.g., invalid dir test)
-			} else {
-				// Assume relative paths are meant to be within the default dir for testing direct screenshot function
-				finalSavePath = filepath.Join(expectedBoxDefaultDir, *tc.params.Path)
-			}
-		} else {
-			// Should not happen if cases are defined correctly (either prefix or explicit path)
-			t.Fatalf("Test case '%s' has neither filenamePrefix nor explicit Path set", tc.name)
-		}
-		// Set the Path field within the params copy for this run
-		currentParams := tc.params
-		currentParams.Path = &finalSavePath
-
-		// Construct Playwright options from the params for this test case
-		screenshotOpts := playwright.PageScreenshotOptions{}
-		screenshotOpts.Path = currentParams.Path // Use the final path
-		if currentParams.Type != nil {
-			if *currentParams.Type == "png" {
-				screenshotOpts.Type = playwright.ScreenshotTypePng
-			} else if *currentParams.Type == "jpeg" || *currentParams.Type == "jpg" {
-				screenshotOpts.Type = playwright.ScreenshotTypeJpeg
-			}
-		}
-		if currentParams.FullPage != nil {
-			screenshotOpts.FullPage = currentParams.FullPage
-		}
-		if currentParams.Quality != nil {
-			// Correctly check type before applying quality
-			isJpeg := false
-			// Assuming playwright.ScreenshotTypeJpeg is *playwright.ScreenshotType based on linter errors
-			// Check if both pointers are non-nil and dereference to compare values
-			if screenshotOpts.Type != nil && playwright.ScreenshotTypeJpeg != nil && *screenshotOpts.Type == *playwright.ScreenshotTypeJpeg {
-				isJpeg = true
-			}
-			if isJpeg {
-				screenshotOpts.Quality = currentParams.Quality
-			}
-		}
-		if currentParams.OmitBackground != nil {
-			screenshotOpts.OmitBackground = currentParams.OmitBackground
-		}
-		if currentParams.Timeout != nil {
-			screenshotOpts.Timeout = currentParams.Timeout
-		}
-		if currentParams.Clip != nil {
-			screenshotOpts.Clip = &playwright.Rect{X: currentParams.Clip.X, Y: currentParams.Clip.Y, Width: currentParams.Clip.Width, Height: currentParams.Clip.Height}
-		}
-		if currentParams.Scale != nil {
-			if *currentParams.Scale == "css" {
-				screenshotOpts.Scale = playwright.ScreenshotScaleCss
-			} else if *currentParams.Scale == "device" {
-				screenshotOpts.Scale = playwright.ScreenshotScaleDevice
-			}
-		}
-		if currentParams.Animations != nil {
-			if *currentParams.Animations == "disabled" {
-				screenshotOpts.Animations = playwright.ScreenshotAnimationsDisabled
-			} else if *currentParams.Animations == "allow" {
-				screenshotOpts.Animations = playwright.ScreenshotAnimationsAllow
-			}
-		}
-		if currentParams.Caret != nil {
-			if *currentParams.Caret == "hide" {
-				screenshotOpts.Caret = playwright.ScreenshotCaretHide
-			} else if *currentParams.Caret == "initial" {
-				screenshotOpts.Caret = playwright.ScreenshotCaretInitial
-			}
-		}
-		// --- End Prepare ---
-
 		t.Run(tc.name, func(t *testing.T) {
-			// --- Final Path Setup (handle temp paths here) ---
-			currentFinalSavePath := finalSavePath // Use outer scope path by default
-			currentExpectedDir := expectedBoxDefaultDir
-
-			if isTempPath {
-				tempDir := t.TempDir() // Generate temp dir specific to this subtest run
-				baseFilename := ""
-				if tc.name == "Specific path (PNG in temp dir)" {
-					baseFilename = "specific_test.png"
-				} else if tc.name == "Specific path (JPEG with Quality in temp dir)" {
-					baseFilename = "specific_test_quality.jpeg"
-				} else if tc.name == "Clip screenshot (in temp dir)" {
-					baseFilename = "clipped.png"
-				}
-				currentFinalSavePath = filepath.Join(tempDir, baseFilename)
-				currentParams.Path = &currentFinalSavePath  // Update path in params for Playwright
-				screenshotOpts.Path = &currentFinalSavePath // Ensure options also have the correct path
-				currentExpectedDir = tempDir                // Update expected dir for validation
+			// --- Prepare Playwright Options ---
+			screenshotOpts := playwright.PageScreenshotOptions{}
+			// Set path only if provided for the test case
+			if tc.outputPath != nil {
+				screenshotOpts.Path = tc.outputPath
 			}
 
-			// Ensure directory exists if this is the relative path test
-			ensureDirExistsForRelativePathTest(t, currentFinalSavePath)
+			// Map other options from params
+			if tc.params.Type != nil {
+				if *tc.params.Type == "png" {
+					screenshotOpts.Type = playwright.ScreenshotTypePng
+				} else if *tc.params.Type == "jpeg" || *tc.params.Type == "jpg" {
+					screenshotOpts.Type = playwright.ScreenshotTypeJpeg
+				}
+			}
+			if tc.params.FullPage != nil {
+				screenshotOpts.FullPage = tc.params.FullPage
+			}
+			if tc.params.Quality != nil {
+				// Ensure type is JPEG before applying quality
+				isJpeg := false
+				if screenshotOpts.Type != nil && *screenshotOpts.Type == *playwright.ScreenshotTypeJpeg {
+					isJpeg = true
+				}
+				if isJpeg {
+					screenshotOpts.Quality = tc.params.Quality
+				}
+			}
+			if tc.params.OmitBackground != nil {
+				screenshotOpts.OmitBackground = tc.params.OmitBackground
+			}
+			if tc.params.Timeout != nil {
+				screenshotOpts.Timeout = tc.params.Timeout
+			}
+			if tc.params.Clip != nil {
+				screenshotOpts.Clip = &playwright.Rect{X: tc.params.Clip.X, Y: tc.params.Clip.Y, Width: tc.params.Clip.Width, Height: tc.params.Clip.Height}
+			}
+			if tc.params.Scale != nil {
+				if *tc.params.Scale == "css" {
+					screenshotOpts.Scale = playwright.ScreenshotScaleCss
+				} else if *tc.params.Scale == "device" {
+					screenshotOpts.Scale = playwright.ScreenshotScaleDevice
+				}
+			}
+			if tc.params.Animations != nil {
+				if *tc.params.Animations == "disabled" {
+					screenshotOpts.Animations = playwright.ScreenshotAnimationsDisabled
+				} else if *tc.params.Animations == "allow" {
+					screenshotOpts.Animations = playwright.ScreenshotAnimationsAllow
+				}
+			}
+			if tc.params.Caret != nil {
+				if *tc.params.Caret == "hide" {
+					screenshotOpts.Caret = playwright.ScreenshotCaretHide
+				} else if *tc.params.Caret == "initial" {
+					screenshotOpts.Caret = playwright.ScreenshotCaretInitial
+				}
+			}
+			// --- End Prepare Playwright Options ---
 
-			// Call page.Screenshot directly using the potentially updated screenshotOpts
-			_, err := page.Screenshot(screenshotOpts)
+			t.Logf("Running test case: %s", tc.name)
+			t.Logf("Playwright Screenshot Options: %+v", screenshotOpts)
 
+			// --- Call Playwright Screenshot Directly ---
+			buffer, err := page.Screenshot(screenshotOpts)
+
+			// --- Assertions ---
 			if tc.expectError {
 				assert.Error(t, err, "Expected an error but got nil")
 				if err != nil {
 					t.Logf("Received expected error: %v", err)
 				}
 				// Clean up potentially partially created file if path was specified
-				_ = os.Remove(currentFinalSavePath)
+				if tc.outputPath != nil {
+					_ = os.Remove(*tc.outputPath)
+				}
 			} else {
 				assert.NoError(t, err, "Expected no error, but got: %v", err)
 				if err != nil {
-					t.FailNow()
+					t.FailNow() // Stop test if screenshot failed unexpectedly
 				}
-				// If no error, proceed with file validation based on finalSavePath
-				// Validate the path format/location
-				if tc.validatePath != nil {
-					// Pass the correctly determined path and expected dir for this run
-					tc.validatePath(t, currentFinalSavePath, currentExpectedDir)
+				// Validate output (file or buffer)
+				if tc.validateOutput != nil {
+					tc.validateOutput(t, tc.outputPath, buffer)
 				}
-
-				// Check if the file actually exists
-				_, statErr := os.Stat(currentFinalSavePath)
-				assert.NoError(t, statErr, "Screenshot file should exist at path: %s", currentFinalSavePath)
-
-				// Basic check for file extension (using the potentially updated path)
-				assert.Equal(t, tc.expectedExt, filepath.Ext(currentFinalSavePath), "File extension should match expected")
 			}
 		})
 	}
 }
 
-// Helper function specifically for the relative path test case inside TestExecuteVisionScreenshot
-// to ensure the directory exists before calling page.Screenshot directly.
-// This mimics the behavior of the actual ExecuteVisionScreenshot service function.
-func ensureDirExistsForRelativePathTest(t *testing.T, finalPath string) {
-	// This helper now needs to create the directory structure including the boxID and subdir
-	// It's only called for the relative path test case
-	// The finalPath passed in should already include the boxID and subdir: e.g., /share/test-box-id/screenshot/subdir/relative_test.png
-	dirToCreate := filepath.Dir(finalPath)
-	t.Logf("Ensuring directory exists for relative path test: %s", dirToCreate)
-	err := os.MkdirAll(dirToCreate, 0755)
-	require.NoError(t, err, "Failed to create directory for relative path test: %s", dirToCreate)
-}
+// ensureDirExistsForRelativePathTest is likely no longer needed or needs significant rework
+// as the service now handles path generation internally for URL format.
+// This helper was designed for tests directly calling page.Screenshot with specific paths.
+// func ensureDirExistsForRelativePathTest(t *testing.T, finalPath string) {
+// 	dirToCreate := filepath.Dir(finalPath)
+// 	t.Logf("Ensuring directory exists for relative path test: %s", dirToCreate)
+// 	err := os.MkdirAll(dirToCreate, 0755)
+// 	require.NoError(t, err, "Failed to create directory for relative path test: %s", dirToCreate)
+// }

--- a/packages/api-server/pkg/box/lifecycle.go
+++ b/packages/api-server/pkg/box/lifecycle.go
@@ -2,14 +2,16 @@ package model
 
 // BoxCreateParams represents a request to create a box
 type BoxCreateParams struct {
-	Image           string            `json:"image,omitempty"`
-	ImagePullSecret string            `json:"image_pull_secret,omitempty"` // For docker: base64 encoded auth string, for k8s: secret name
-	Env             map[string]string `json:"env,omitempty"`
-	Cmd             string            `json:"cmd,omitempty"`
-	Args            []string          `json:"args,omitempty"`
-	WorkingDir      string            `json:"working_dir,omitempty"`
-	ExtraLabels     map[string]string `json:"extra_labels,omitempty"`
-	Volumes         []VolumeMount     `json:"volumes,omitempty"` // Volume mounts for the container
+	Image                      string            `json:"image,omitempty"`
+	ImagePullSecret            string            `json:"image_pull_secret,omitempty"` // For docker: base64 encoded auth string, for k8s: secret name
+	Env                        map[string]string `json:"env,omitempty"`
+	Cmd                        string            `json:"cmd,omitempty"`
+	Args                       []string          `json:"args,omitempty"`
+	WorkingDir                 string            `json:"working_dir,omitempty"`
+	ExtraLabels                map[string]string `json:"extra_labels,omitempty"`
+	Volumes                    []VolumeMount     `json:"volumes,omitempty"`                        // Volume mounts for the container
+	WaitForReady               bool              `json:"wait_for_ready,omitempty"`                 // + Wait for box to be ready (healthy)
+	WaitForReadyTimeoutSeconds int               `json:"wait_for_ready_timeout_seconds,omitempty"` // + Timeout for readiness check
 }
 
 // VolumeMount represents a volume mount configuration

--- a/packages/api-server/pkg/browser/page_action.go
+++ b/packages/api-server/pkg/browser/page_action.go
@@ -104,9 +104,6 @@ type VisionMoveParams struct {
 // VisionScreenshotParams corresponds to the props for the vision.screenshot action based on ScreenshotActionSchema.
 // Aligned with relevant options from playwright.PageScreenshotOptions.
 type VisionScreenshotParams struct {
-	// Path specifies the file path to save the screenshot to.
-	// If omitted, the screenshot is returned as a base64 encoded string.
-	Path *string `json:"path,omitempty"`
 
 	// When true, takes a screenshot of the full scrollable page. Defaults to false.
 	FullPage *bool `json:"fullPage,omitempty"`
@@ -135,7 +132,8 @@ type VisionScreenshotParams struct {
 	// Caret visibility ('hide', 'initial'). Defaults to 'hide'.
 	Caret *string `json:"caret,omitempty"` // Consider enum ScreenshotCaret
 
-	// TODO: Consider adding Mask, MaskColor, Style if needed later.
+	// Output format ('url' or 'base64'). Defaults to 'base64'.
+	OutputFormat *string `json:"output_format,omitempty"`
 }
 
 // VisionScrollParams corresponds to the props for the vision.scroll action based on ScrollActionSchema.
@@ -189,8 +187,9 @@ type VisionScrollResult struct {
 
 // VisionScreenshotResult is returned when ActionVisionScreenshot saves to a file.
 type VisionScreenshotResult struct {
-	Success   bool   `json:"success"`   // Always true for this type
-	SavedPath string `json:"savedPath"` // The absolute path where the screenshot was saved.
+	Success       bool   `json:"success"`                  // Always true for this type
+	URL           string `json:"url,omitempty"`            // URL if output_format is "url"
+	Base64Content string `json:"base64_content,omitempty"` // Base64 encoded content if output_format is "base64"
 }
 
 // VisionScreenshotBase64Result is returned when ActionVisionScreenshot returns base64 data.

--- a/packages/cli/cmd/mcp_export.go
+++ b/packages/cli/cmd/mcp_export.go
@@ -14,7 +14,8 @@ import (
 
 // Define the structure for the new MCP server entry using URL
 type McpServerEntry struct {
-	Url string `json:"url"`
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
 }
 
 // Keep McpConfig using the specific new entry type for generation
@@ -111,10 +112,12 @@ func exportConfig(mergeTo string, dryRun bool) error {
 	cursorConfig := filepath.Join(homeDir, ".cursor", "mcp.json")
 
 	// configToExport remains the definitive new structure to be added/updated
+	mcpServerURL := strings.TrimSuffix(config.GetMcpServerUrl(), "/") + "/sse" // Get and format URL once
 	configToExport := McpConfig{
 		McpServers: map[string]McpServerEntry{
 			"gbox": {
-				Url: config.GetMcpServerUrl(), // Use URL from config
+				Command: "npx",
+				Args:    []string{"mcp-remote", mcpServerURL}, // Use formatted URL
 			},
 		},
 	}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -9,6 +9,8 @@ import {
   READ_FILE_DESCRIPTION,
   WRITE_FILE_TOOL,
   WRITE_FILE_DESCRIPTION,
+  LIST_BOXES_TOOL,
+  LIST_BOXES_DESCRIPTION,
   handleRunPython,
   handleRunBash,
   handleReadFile,
@@ -17,6 +19,11 @@ import {
   readFileParams,
   handleWriteFile,
   writeFileParams,
+  handleListBoxes,
+  VIEW_URL_AS_TOOL,
+  VIEW_URL_AS_DESCRIPTION,
+  viewUrlAsParams,
+  handleViewUrlAs,
 } from "./tools/index.js";
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import express from "express";
@@ -91,13 +98,12 @@ mcpServer.prompt(
 
 // Register tools
 
-// This is meaningless for now, because we don't have a way to explicitly create a box.
-// mcpServer.tool(
-//   LIST_BOXES_TOOL,
-//   LIST_BOXES_DESCRIPTION,
-//   {},
-//   handleListBoxes(log)
-// );
+mcpServer.tool(
+  LIST_BOXES_TOOL,
+  LIST_BOXES_DESCRIPTION,
+  {},
+  handleListBoxes(logger)
+);
 
 mcpServer.tool(
   READ_FILE_TOOL,
@@ -127,6 +133,12 @@ mcpServer.tool(
   handleRunBash(logger)
 );
 
+mcpServer.tool(
+  VIEW_URL_AS_TOOL,
+  VIEW_URL_AS_DESCRIPTION,
+  viewUrlAsParams,
+  handleViewUrlAs(logger)
+);
 app.get("/sse", (req, res) => {
   transport = new SSEServerTransport("/messages", res);
   mcpServer.connect(transport);
@@ -141,5 +153,5 @@ app.post("/messages", (req, res) => {
 const port = process.env.PORT || 28090;
 
 app.listen(port, () => {
-  console.log(`Server started successfully on port ${port}`);
+  // console.log(`Server started successfully on port ${port}`);
 });

--- a/packages/mcp-server/src/sdk/browser.ts
+++ b/packages/mcp-server/src/sdk/browser.ts
@@ -1,0 +1,174 @@
+import type { Client } from "./client";
+import type {
+  CreateContextParams,
+  CreateContextResult,
+  CreatePageParams,
+  CreatePageResult,
+  GetPageParams,
+  GetPageResult,
+  ListPagesResult,
+  VisionScreenshotParams,
+  VisionScreenshotResult,
+  BrowserErrorResult,
+} from "./types";
+
+/**
+ * Operations related to a specific browser page within a context.
+ */
+export class PageOperations {
+  constructor(
+    private apiClient: Client,
+    private boxId: string,
+    private contextId: string,
+    private pageId: string
+  ) {}
+
+  /**
+   * Get details for this specific page.
+   * @param params Options for retrieving content.
+   * @returns Page details, potentially including content.
+   */
+  async get(params?: GetPageParams): Promise<GetPageResult> {
+    const queryParams = new URLSearchParams();
+    if (params?.withContent !== undefined) {
+      queryParams.set("withContent", String(params.withContent));
+    }
+    if (params?.contentType) {
+      queryParams.set("contentType", params.contentType);
+    }
+    const queryString = queryParams.toString();
+    const url = `/boxes/${this.boxId}/browser-contexts/${
+      this.contextId
+    }/pages/${this.pageId}${queryString ? `?${queryString}` : ""}`;
+    const response = await this.apiClient.get(url);
+    return response.json();
+  }
+
+  /**
+   * Close this specific page.
+   */
+  async close(): Promise<void> {
+    const url = `/boxes/${this.boxId}/browser-contexts/${this.contextId}/pages/${this.pageId}`;
+    await this.apiClient.delete(url);
+  }
+
+  /**
+   * Take a screenshot of the current page.
+   * @param params Screenshot options.
+   * @returns Result containing the path to the saved screenshot or an error.
+   */
+  async screenshot(
+    params: VisionScreenshotParams = {}
+  ): Promise<VisionScreenshotResult | BrowserErrorResult> {
+    const url = `/boxes/${this.boxId}/browser-contexts/${this.contextId}/pages/${this.pageId}/actions/vision-screenshot`;
+    const response = await this.apiClient.post(url, {
+      body: JSON.stringify(params),
+    });
+    return response.json();
+  }
+
+  // TODO: Add methods for Vision Actions (click, type, screenshot, etc.)
+  // Example:
+  // async click(params: VisionClickParams): Promise<VisionClickResult | BrowserErrorResult> {
+  //   const url = `/boxes/${this.boxId}/browser-contexts/${this.contextId}/pages/${this.pageId}/actions/vision-click`;
+  //   return this.apiClient.request<VisionClickResult | BrowserErrorResult>('POST', url, params);
+  // }
+}
+
+/**
+ * Operations related to pages within a specific browser context.
+ */
+export class ContextPageOperations {
+  constructor(
+    private apiClient: Client,
+    private boxId: string,
+    private contextId: string
+  ) {}
+
+  /**
+   * Create a new page within this context and navigate it.
+   * @param params Page creation parameters (URL, etc.).
+   * @returns Result of the page creation.
+   */
+  async create(params: CreatePageParams): Promise<CreatePageResult> {
+    const url = `/boxes/${this.boxId}/browser-contexts/${this.contextId}/pages`;
+    const response = await this.apiClient.post(url, {
+      body: JSON.stringify(params),
+    });
+    return response.json();
+  }
+
+  /**
+   * List all pages within this context.
+   * @returns List of page IDs.
+   */
+  async list(): Promise<ListPagesResult> {
+    const url = `/boxes/${this.boxId}/browser-contexts/${this.contextId}/pages`;
+    const response = await this.apiClient.get(url);
+    return response.json();
+  }
+
+  /**
+   * Get operations for a specific page within this context.
+   * @param pageId The ID of the page.
+   * @returns PageOperations instance.
+   */
+  page(pageId: string): PageOperations {
+    return new PageOperations(
+      this.apiClient,
+      this.boxId,
+      this.contextId,
+      pageId
+    );
+  }
+}
+
+/**
+ * Operations related to browser contexts within a specific box.
+ */
+export class BrowserContextOperations {
+  constructor(private apiClient: Client, private boxId: string) {}
+
+  /**
+   * Create a new browser context within this box.
+   * @param params Context creation parameters.
+   * @returns Result of the context creation.
+   */
+  async create(params?: CreateContextParams): Promise<CreateContextResult> {
+    const url = `/boxes/${this.boxId}/browser-contexts`;
+    const response = await this.apiClient.post(url, {
+      body: JSON.stringify(params ?? {}),
+    });
+
+    // Check if the request was successful
+    if (!response.ok) {
+      // Attempt to read the response body as text for more detailed error logging
+      let errorBody = await response
+        .text()
+        .catch(() => "Failed to read error body");
+      throw new Error(
+        `Failed to create browser context: ${response.status} ${response.statusText}. Body: ${errorBody}`
+      );
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Close a specific browser context within this box.
+   * @param contextId The ID of the context to close.
+   */
+  async close(contextId: string): Promise<void> {
+    const url = `/boxes/${this.boxId}/browser-contexts/${contextId}`;
+    await this.apiClient.delete(url);
+  }
+
+  /**
+   * Get operations for pages within a specific context.
+   * @param contextId The ID of the browser context.
+   * @returns ContextPageOperations instance.
+   */
+  pages(contextId: string): ContextPageOperations {
+    return new ContextPageOperations(this.apiClient, this.boxId, contextId);
+  }
+}

--- a/packages/mcp-server/src/sdk/client.ts
+++ b/packages/mcp-server/src/sdk/client.ts
@@ -56,24 +56,19 @@ export class Client {
     return response;
   }
 
-  async get(
-    path: string,
-    options: ClientRequestOptions = {}
-  ): Promise<Response> {
+  async get(path: string, options: ClientRequestOptions = {}): Promise<Response> {
     return this.request(path, { ...options, method: "GET" });
   }
 
-  async head(
-    path: string,
-    options: ClientRequestOptions = {}
-  ): Promise<Response> {
+  async head(path: string, options: ClientRequestOptions = {}): Promise<Response> {
     return this.request(path, { ...options, method: "HEAD" });
   }
 
-  async post(
-    path: string,
-    options: ClientRequestOptions = {}
-  ): Promise<Response> {
+  async post(path: string, options: ClientRequestOptions = {}): Promise<Response> {
     return this.request(path, { ...options, method: "POST" });
+  }
+
+  async delete(path: string, options: ClientRequestOptions = {}): Promise<Response> {
+    return this.request(path, { ...options, method: "DELETE" });
   }
 }

--- a/packages/mcp-server/src/sdk/types.ts
+++ b/packages/mcp-server/src/sdk/types.ts
@@ -32,6 +32,8 @@ export interface CreateBoxOptions {
   image: string;
   sessionId?: string;
   signal?: AbortSignal;
+  waitForReady?: boolean;
+  waitForReadyTimeoutSeconds?: number;
 }
 
 export interface RunOptions {
@@ -67,3 +69,104 @@ export const FILE_SIZE_LIMITS = {
   TEXT: 1024 * 1024, // 1MB for text files
   BINARY: 5 * 1024 * 1024, // 5MB for binary files (images, audio)
 } as const;
+
+// --- Browser Context Types ---
+
+export interface CreateContextParams {
+  // Add options if defined in Go model (e.g., playwright options)
+  // Example: userAgent?: string;
+}
+
+export interface CreateContextResult {
+  context_id: string;
+  // Add other fields if defined in Go model
+}
+
+// --- Browser Page Types ---
+
+// Map playwright WaitUntilState (string enums in Go likely)
+export type WaitUntilState =
+  | "load"
+  | "domcontentloaded"
+  | "networkidle"
+  | "commit";
+
+export interface CreatePageParams {
+  url: string;
+  wait_until?: WaitUntilState;
+  timeout?: number; // milliseconds
+}
+
+export interface CreatePageResult {
+  page_id: string;
+  url: string;
+  title: string;
+}
+
+export interface ListPagesResult {
+  page_ids: string[];
+}
+
+export interface GetPageParams {
+  withContent?: boolean;
+  contentType?: "html" | "markdown";
+}
+
+export interface GetPageResult {
+  page_id: string;
+  url: string;
+  title: string;
+  content?: string;
+  contentType?: "text/html" | "text/markdown"; // MIME types
+}
+
+// --- Browser Action Error Types ---
+
+// Using a generic error result type for actions for now
+// Matches Go's model.VisionErrorResult structure
+export interface BrowserErrorResult {
+  success: false;
+  error: string;
+}
+
+// Type guard to check for browser errors
+export function isBrowserErrorResult(obj: any): obj is BrowserErrorResult {
+  return obj && obj.success === false && typeof obj.error === "string";
+}
+
+// --- Vision Action Specific Types ---
+
+// Corresponds to Go's model.Rect
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+// Corresponds to Go's model.VisionScreenshotParams
+export interface VisionScreenshotParams {
+  // path?: string; // REMOVED: No longer specified by client
+  type?: "png" | "jpeg";
+  quality?: number; // 0-100, only for jpeg
+  fullPage?: boolean;
+  clip?: Rect;
+  omitBackground?: boolean;
+  timeout?: number; // milliseconds
+  scale?: "css" | "device";
+  animations?: "disabled" | "allow";
+  caret?: "hide" | "initial";
+  output_format?: "url" | "base64"; // ADDED: Specify output format
+  // Add other options if needed based on Go struct
+}
+
+// Corresponds to Go's model.VisionScreenshotResult
+export interface VisionScreenshotResult {
+  success: true;
+  // savedPath: string; // REMOVED: Replaced by URL or base64 content
+  url?: string; // ADDED: URL if output_format is "url"
+  base64_content?: string; // ADDED: Base64 content if output_format is "base64"
+}
+
+// Consider adding other Vision Action types here later if needed
+// e.g., VisionClickParams, VisionClickResult, etc.

--- a/packages/mcp-server/src/tools/__tests__/list-boxes.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/list-boxes.test.ts
@@ -1,19 +1,30 @@
-import { describe, it, expect, vi } from 'vitest';
-import { handleListBoxes } from '../index';
+import { describe, it, expect, vi } from "vitest";
+import { handleListBoxes } from "../index";
+import type { Logger } from "../../sdk/types";
 
-describe('handleListBoxes', () => {
-  it('should return a list of boxes', async () => {
-    const mockLog = vi.fn();
-    const handler = handleListBoxes(mockLog);
-    
-    const result = await handler({}, {}, {
-      sessionId: 'test-session',
-      signal: new AbortController().signal
-    });
-    
+describe("handleListBoxes", () => {
+  it("should return a list of boxes", async () => {
+    const mockLogger: Logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const handler = handleListBoxes(mockLogger);
+
+    const result = await handler(
+      {},
+      {},
+      {
+        sessionId: "test-session",
+        signal: new AbortController().signal,
+      }
+    );
+
     expect(result).toBeDefined();
     expect(result.content).toBeDefined();
     expect(Array.isArray(result.content)).toBe(true);
-    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].type).toBe("text");
   });
-}); 
+});

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -3,6 +3,7 @@ export * from "./run-python.js";
 export * from "./run-bash.js";
 export * from "./read-file.js";
 export * from "./write-file.js";
+export * from "./view-url-as.js";
 
 // Re-export tool names and descriptions for convenience
 export const TOOL_NAMES = {
@@ -11,6 +12,7 @@ export const TOOL_NAMES = {
   RUN_BASH: "run-bash",
   READ_FILE: "read-file",
   WRITE_FILE: "write-file",
+  VIEW_URL_AS: "view-url-as",
 } as const;
 
 export type ToolName = (typeof TOOL_NAMES)[keyof typeof TOOL_NAMES];

--- a/packages/mcp-server/src/tools/list-boxes.ts
+++ b/packages/mcp-server/src/tools/list-boxes.ts
@@ -17,7 +17,7 @@ export const handleListBoxes = withLogging(
 
     const response = await gbox.box.getBoxes({ signal, sessionId });
 
-    logger.info(`Found ${response.boxes.length} boxes`);
+    logger.info(`Found ${response.count} boxes`);
 
     return {
       content: [

--- a/packages/mcp-server/src/tools/view-url-as.ts
+++ b/packages/mcp-server/src/tools/view-url-as.ts
@@ -1,0 +1,289 @@
+import { z } from "zod";
+import { GBox } from "../sdk"; // Assuming GBox provides client and boxId
+import { Client } from "../sdk/client"; // Import Client type
+import {
+  BrowserContextOperations,
+  ContextPageOperations,
+  PageOperations,
+} from "../sdk/browser"; // Import operation classes
+import type {
+  Logger,
+  VisionScreenshotParams, // Import the specific type
+  VisionScreenshotResult, // Import the specific type
+  BrowserErrorResult, // Added missing import
+} from "../sdk/types";
+import { isBrowserErrorResult } from "../sdk/types"; // Import type guard if needed
+import { withLogging } from "../utils.js"; // Added import
+import { config } from "../config.js"; // Added import
+
+// Define the Zod schema for the tool's parameters, including name and description
+export const ViewUrlAsSchema = z.object({
+  name: z.literal("view-url-as"),
+  description: z
+    .string()
+    .default(
+      "Fetch and view content from a URL as HTML, Markdown, or screenshot. Optionally specify a boxId to reuse a specific browser session."
+    )
+    .describe(
+      // Using .describe() for a potentially longer description if needed elsewhere
+      "Navigates to a URL in a browser context and returns its content as HTML, Markdown, or takes a screenshot. Use the boxId parameter to maintain session state across calls."
+    ),
+  parameters: z.object({
+    url: z.string().url({
+      message:
+        "The URL to fetch content from (must start with http:// or https://).",
+    }),
+    as: z.enum(["html", "markdown", "screenshot"], {
+      errorMap: () => ({
+        message:
+          "The desired output format: 'html', 'markdown', or 'screenshot'.",
+      }),
+    }),
+    boxId: z.preprocess(
+      // Preprocess to handle null input
+      (val) => (val === null ? undefined : val),
+      z.string().optional() // Keep the original validation
+    ) // Added boxId
+      .describe(`The ID of an existing browser box to use.
+        If not provided, the system will try to reuse an existing box with a browser image.
+        The system will first try to use a running box, then a stopped box (which will be started), and finally create a new one if needed.
+        Note that without boxId, multiple calls may use different boxes even if they exist.
+        If you need to ensure multiple calls use the same box, you must provide a boxId.
+        You can get the list of existing boxes by using the list-boxes tool.
+        `),
+  }),
+});
+
+// Derive constants from the schema
+export const VIEW_URL_AS_TOOL = ViewUrlAsSchema.shape.name.value;
+export const VIEW_URL_AS_DESCRIPTION =
+  ViewUrlAsSchema.shape.description._def.defaultValue(); // Get the default value
+export const viewUrlAsParams = ViewUrlAsSchema.shape.parameters.shape; // Use .shape to get the raw shape for McpServer.tool
+
+// Define the expected content structure(s)
+type TextContent = { type: "text"; text: string };
+type ImageContent = { type: "image"; data: string; mimeType: string };
+type ErrorContent = { type: "error"; text: string };
+type ResultContent = TextContent | ImageContent | ErrorContent;
+
+// Infer the type for the parameters object from the schema
+type ViewUrlAsParams = z.infer<typeof ViewUrlAsSchema.shape.parameters>;
+
+// Define the internal action function for the tool
+async function _handleViewUrlAs(
+  logger: Logger, // Logger comes first from withLogging
+  { url, as, boxId }: ViewUrlAsParams, // Destructure params
+  { signal, sessionId }: { signal: AbortSignal; sessionId?: string }
+): Promise<{ content: Array<ResultContent> }> {
+  // UPDATED return type
+  const gbox = new GBox({
+    apiUrl: config.apiServer.url,
+    logger,
+  });
+
+  // Note: Assuming gbox.client is the correct way to get the Client instance
+  const client = gbox.client; // Get client from gbox instance
+
+  if (!client) {
+    // Check if client is available
+    const errorMsg = "GBox client is missing for browser operations.";
+    logger.error(errorMsg);
+    return { content: [{ type: "error", text: errorMsg }] };
+  }
+
+  let contextOps: BrowserContextOperations | null = null;
+  let pageOps: PageOperations | null = null;
+  let contextId: string | null = null;
+  let pageId: string | null = null;
+  let actualBoxId: string | null = null; // To store the obtained box ID
+
+  try {
+    // Get or create box
+    actualBoxId = await gbox.box.getOrCreateBox({
+      boxId,
+      image: config.images.python, // Assuming python image has the playwright server
+      sessionId,
+      signal,
+      waitForReady: true, // Wait for the box healthcheck to pass
+      waitForReadyTimeoutSeconds: 60, // Timeout after 60 seconds
+    });
+
+    logger.info(
+      `Attempting to view URL: ${url} as ${as} in box ${actualBoxId} ${
+        sessionId ? `for session: ${sessionId}` : ""
+      }`
+    );
+
+    // Instantiate BrowserContextOperations with obtained boxId
+    contextOps = new BrowserContextOperations(client, actualBoxId);
+
+    // 1. Create a new browser context
+    const contextResult = await contextOps.create(/* { signal } */);
+    contextId = contextResult.context_id;
+    logger.debug(`Created browser context: ${contextId}`);
+
+    // Instantiate ContextPageOperations with obtained boxId
+    const contextPageOps = new ContextPageOperations(
+      client,
+      actualBoxId,
+      contextId
+    );
+
+    // 2. Create a new page and navigate to the URL
+    const pageParams = {
+      url,
+      wait_until: "load" as const, // Use const assertion
+    };
+    const pageResult = await contextPageOps.create(pageParams);
+    pageId = pageResult.page_id;
+    logger.debug(`Created page ${pageId} and navigated to URL: ${url}`);
+
+    // Instantiate PageOperations with obtained boxId
+    pageOps = new PageOperations(client, actualBoxId, contextId, pageId);
+
+    // 3. Perform the requested action
+    let resultText: string | undefined; // Make optional as it's not always set
+    switch (as) {
+      case "html": {
+        const getParams = {
+          withContent: true,
+          contentType: "html" as const, // Use const assertion
+        };
+        const result = await pageOps.get(getParams);
+        logger.info(
+          `Fetched HTML content for ${url}. Length: ${
+            result.content?.length ?? 0
+          }`
+        );
+        resultText = result.content ?? "";
+        break;
+      }
+      case "markdown": {
+        const getParams = {
+          withContent: true,
+          contentType: "markdown" as const, // Use const assertion
+        };
+        const result = await pageOps.get(getParams);
+        logger.info(
+          `Fetched Markdown content for ${url}. Length: ${
+            result.content?.length ?? 0
+          }`
+        );
+        resultText = result.content ?? "";
+        break;
+      }
+      case "screenshot": {
+        // Specify base64 output format and pass type from input params
+        const screenshotParams: VisionScreenshotParams = {
+          output_format: "base64" as const,
+          // Determine type based on the 'as' parameter logic (though screenshot always returns png/jpeg)
+          // The backend decides the actual format, but we can hint based on future extensions
+          // For now, the backend defaults to png if type is not jpeg.
+          // type: as === 'screenshot' ? undefined : as, // This logic is flawed
+        };
+        // Potentially refine type based on future params, for now API handles default
+
+        const result: VisionScreenshotResult | BrowserErrorResult =
+          await pageOps.screenshot(screenshotParams);
+
+        if (result.success === true && result.base64_content) {
+          logger.info(
+            `Took screenshot for ${url}, returning base64 data (length: ${result.base64_content.length}).`
+          );
+
+          // Determine MIME type - NEEDS IMPROVEMENT
+          // Ideally, the backend API should return the actual mime type.
+          // For now, we assume PNG unless the backend explicitly signals JPEG (which it doesn't directly).
+          // We *cannot* reliably infer the type from the base64 string itself without more complex logic.
+          // Defaulting to png as per current backend behavior.
+          let mimeType = "image/png";
+          // if (screenshotParams.type === "jpeg") { // Cannot reliably check screenshotParams.type here
+          //    mimeType = "image/jpeg";
+          // }
+
+          // Return the structured image content directly
+          return {
+            content: [
+              {
+                type: "image" as const,
+                data: result.base64_content,
+                mimeType: mimeType, // Using assumed PNG mime type
+              },
+            ],
+          };
+        } else if (result.success === true && !result.base64_content) {
+          const errorMsg = `Screenshot succeeded but base64 content is missing.`;
+          logger.error(errorMsg);
+          return { content: [{ type: "error", text: errorMsg }] };
+        } else if (isBrowserErrorResult(result)) {
+          const errorMsg = `Screenshot failed: ${result.error}`;
+          logger.error(`Failed to take screenshot for ${url}: ${result.error}`);
+          return { content: [{ type: "error", text: errorMsg }] };
+        } else {
+          const errorMsg = `Screenshot failed with unexpected result format.`;
+          logger.error(
+            `Unexpected screenshot result format for ${url}: ${JSON.stringify(
+              result
+            )}`
+          );
+          return { content: [{ type: "error", text: errorMsg }] };
+        }
+        // No resultText is set here, return happened above or in error cases
+        break; // Break is technically redundant due to returns, but good practice
+      }
+      default: {
+        const exhaustiveCheck: never = as;
+        const errorMsg = `Internal error: Unhandled format '${exhaustiveCheck}'`;
+        logger.error(`Unhandled 'as' value: ${exhaustiveCheck}`);
+        return { content: [{ type: "error", text: errorMsg }] };
+      }
+    }
+
+    // Return success content for text-based formats if resultText was set
+    if (resultText !== undefined) {
+      return { content: [{ type: "text", text: resultText }] };
+    } else {
+      // Should ideally not be reached if all paths return or throw
+      const errorMsg = "Internal error: Reached end of switch without result.";
+      logger.error(errorMsg);
+      return { content: [{ type: "error", text: errorMsg }] };
+    }
+  } catch (error: any) {
+    const errorMsg = `Operation failed: ${error.message || String(error)}`;
+    logger.error(
+      `Error viewing URL ${url} as ${as}: ${error.message || error}`
+    );
+    // Return error content
+    return { content: [{ type: "error", text: errorMsg }] };
+  } finally {
+    // 4. Ensure cleanup: Close page and context
+    // Note: Signal is not typically passed to cleanup operations
+    if (pageOps) {
+      try {
+        logger.debug(`Closing page ${pageId}...`);
+        await pageOps.close();
+      } catch (closePageError: any) {
+        logger.warn(
+          `Failed to close page ${pageId}: ${
+            closePageError.message || closePageError
+          }`
+        );
+      }
+    }
+    if (contextOps && contextId) {
+      try {
+        logger.debug(`Closing context ${contextId}...`);
+        await contextOps.close(contextId);
+      } catch (closeContextError: any) {
+        logger.warn(
+          `Failed to close context ${contextId}: ${
+            closeContextError.message || closeContextError
+          }`
+        );
+      }
+    }
+  }
+}
+
+// Export the wrapped function
+export const handleViewUrlAs = withLogging(_handleViewUrlAs);

--- a/packages/mcp-server/src/tools/write-file.ts
+++ b/packages/mcp-server/src/tools/write-file.ts
@@ -1,7 +1,7 @@
 import { withLogging } from "../utils.js";
 import { config } from "../config.js";
 import { GBox } from "../sdk/index.js";
-import { MCPLogger } from "../mcp-logger.js";
+import type { Logger } from "../sdk/types";
 import { z } from "zod";
 
 export const WRITE_FILE_TOOL = "write-file";
@@ -18,8 +18,7 @@ export const writeFileParams = {
 };
 
 export const handleWriteFile = withLogging(
-  async (log, { path, content, boxId }, { signal }) => {
-    const logger = new MCPLogger(log);
+  async (logger: Logger, { path, content, boxId }, { signal }) => {
     const gbox = new GBox({
       apiUrl: config.apiServer.url,
       logger,
@@ -27,7 +26,12 @@ export const handleWriteFile = withLogging(
 
     logger.info(`Writing to file: ${path} from box: ${boxId}`);
 
-    const writeResponse =  await gbox.file.writeFile(boxId, path, content, signal);
+    const writeResponse = await gbox.file.writeFile(
+      boxId,
+      path,
+      content,
+      signal
+    );
     if (!writeResponse || !writeResponse.success) {
       return {
         content: [


### PR DESCRIPTION
- Update Dockerfile for Python image with entrypoint script and health check
- Modify Makefile to publish all ports when running images
- Add browser service configuration for health checks
- Improve error handling in box lifecycle management
- Update vision screenshot functionality for base64 and URL outputs
- Enhance logging and error handling across services