### PR TITLE
:star: feat: enhance vision test functionality and improve Makefile

### DIFF
--- a/packages/api-server/Makefile
+++ b/packages/api-server/Makefile
@@ -1,3 +1,9 @@
+# ANSI Color Variables
+BOLD    := $(shell tput bold)
+GREEN   := $(shell tput setaf 2)
+BLUE    := $(shell tput setaf 4)
+RESET   := $(shell tput sgr0)
+
 # Image URL to use all building/pushing image targets
 IMG ?= babelcloud/gbox-api-server:latest
 
@@ -24,8 +30,8 @@ GOARCH ?= $(shell go env GOARCH)
 
 # LDFLAGS for embedding version information
 LDFLAGS := -ldflags "-X $(VERSION_PKG).Version=$(VERSION) \
-                     -X $(VERSION_PKG).BuildTime=$(BUILD_TIME) \
-                     -X $(VERSION_PKG).CommitID=$(COMMIT_ID)"
+                    -X $(VERSION_PKG).BuildTime=$(BUILD_TIME) \
+                    -X $(VERSION_PKG).CommitID=$(COMMIT_ID)"
 
 # Show help
 .PHONY: help
@@ -62,10 +68,10 @@ binary-all: ## Build binaries for all platforms
 .PHONY: docker-build
 docker-build: ## Build docker image locally
 	docker build \
-	  --build-arg VERSION=$(VERSION) \
-	  --build-arg COMMIT_ID=$(COMMIT_ID) \
-	  --build-arg BUILD_TIME=$(BUILD_TIME) \
-	  -t ${IMG} .
+		--build-arg VERSION=$(VERSION) \
+		--build-arg COMMIT_ID=$(COMMIT_ID) \
+		--build-arg BUILD_TIME=$(BUILD_TIME) \
+		-t ${IMG} .
 
 # Build multi-architecture docker image
 .PHONY: docker-buildx
@@ -107,3 +113,11 @@ check-docker-socket: ## Check and create Docker socket symlink if needed
 .PHONY: docker-run
 docker-run: docker-build check-docker-socket ## Run docker container locally
 	docker run -p 28080:28080 --rm -v /var/run/docker.sock:/var/run/docker.sock ${IMG}
+
+# Serve the vision test HTML page locally (Foreground) and open browser (macOS)
+.PHONY: serve-vision-test
+serve-vision-test: ## Serve vision-test.html on port 8070 (Foreground), open browser (macOS)
+	@bash -c 'sleep 0.3 && open http://localhost:8070/vision-test.html || echo "Failed to open browser automatically."' &
+	@echo "Serving vision-test.html at: $(BOLD)$(BLUE)http://localhost:8070/vision-test.html$(RESET)"
+	@echo "Press $(BOLD)$(GREEN)Ctrl+C$(RESET) to stop the server."
+	@cd internal/browser/testdata && python -m http.server -b 127.0.0.1 8070

--- a/packages/api-server/internal/browser/service/page_action_vision_test.go
+++ b/packages/api-server/internal/browser/service/page_action_vision_test.go
@@ -3,13 +3,14 @@ package service_test
 import (
 	"encoding/base64"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,6 +18,35 @@ import (
 	"github.com/babelcloud/gbox/packages/api-server/config"
 	model "github.com/babelcloud/gbox/packages/api-server/pkg/browser"
 )
+
+// Shared screenshot directory for the current test run
+var (
+	testRunScreenshotDir  string
+	initScreenshotDirOnce sync.Once
+)
+
+// getTestRunScreenshotDir ensures a unique directory is created once per test run
+// and returns the path to that directory.
+func getTestRunScreenshotDir(t *testing.T) string {
+	t.Helper() // Mark this as a test helper
+	initScreenshotDirOnce.Do(func() {
+		// Use a timestamp combined with the base name for the directory name
+		timestamp := time.Now().Format("20060102-150405") // YYYYMMDD-HHMMSS format
+		dirName := fmt.Sprintf("screenshots_%s", timestamp)
+		baseOutputDir := filepath.Join("..", "..", "..", ".test-output") // Parent directory
+		testRunScreenshotDir = filepath.Join(baseOutputDir, dirName)     // Combine parent and new dir name
+		err := os.MkdirAll(testRunScreenshotDir, 0755)
+		// Use require inside Do might be tricky for test lifecycle, Fatalf is safer here
+		if err != nil {
+			t.Fatalf("Failed to create shared screenshot directory '%s': %v", testRunScreenshotDir, err)
+		}
+		t.Logf("Created shared screenshot directory for test run: %s", testRunScreenshotDir)
+	})
+	if testRunScreenshotDir == "" {
+		t.Fatal("Shared screenshot directory was not initialized")
+	}
+	return testRunScreenshotDir
+}
 
 // --- Mock BoxService --- (Moved to test_helpers.go)
 /*
@@ -62,7 +92,7 @@ func setupPlaywrightPage(t *testing.T) (playwright.Page, func()) {
 
 	// Launch browser locally
 	browser, err := pw.Chromium.Launch(playwright.BrowserTypeLaunchOptions{
-		Headless: playwright.Bool(false), // Run non-headless for debugging
+		Headless: playwright.Bool(true), // Run headless
 	})
 	require.NoError(t, err, "could not launch local browser")
 
@@ -77,7 +107,7 @@ func setupPlaywrightPage(t *testing.T) (playwright.Page, func()) {
 	fmt.Printf("Navigating test page to %s...\n", testURL)
 	_, err = page.Goto(testURL, playwright.PageGotoOptions{
 		WaitUntil: playwright.WaitUntilStateLoad, // Wait for page to load
-		Timeout:   playwright.Float(10000),      // 10 second timeout for local file
+		Timeout:   playwright.Float(10000),       // 10 second timeout for local file
 	})
 	require.NoError(t, err, "could not navigate to test page %s", testURL)
 	fmt.Printf("Navigation to %s complete.\n", testURL)
@@ -346,10 +376,8 @@ func TestVisionClick(t *testing.T) {
 	svc, boxID, contextID, pageID, page, cleanup := setupServiceWithVisionTestPage(t)
 	defer cleanup()
 
-	// --- Create output directory ---
-	screenshotDir := filepath.Join("..", "..", "..", ".test-output", "screenshots") // Relative path to api-server/.test-output/screenshots
-	err := os.MkdirAll(screenshotDir, 0755)
-	require.NoError(t, err, "Failed to create screenshot directory: %s", screenshotDir)
+	// --- Get shared output directory for this test run ---
+	testScreenshotDir := getTestRunScreenshotDir(t)
 
 	// --- 1. Define Target and Get Coordinates ---
 	buttonSelector := "#click-btn"
@@ -362,8 +390,7 @@ func TestVisionClick(t *testing.T) {
 	clickY := bbox.Y + bbox.Height/2
 
 	// --- 2. Take Pre-click Screenshot ---
-	// Save to project directory instead of temp
-	preClickPath := filepath.Join(screenshotDir, fmt.Sprintf("click_before_%s.png", uuid.NewString()))
+	preClickPath := filepath.Join(testScreenshotDir, "click_before.png") // Use shared dir and descriptive name
 	_, err = page.Screenshot(playwright.PageScreenshotOptions{Path: &preClickPath})
 	require.NoError(t, err, "Failed to take pre-click screenshot")
 	t.Logf("Pre-click screenshot saved to: %s", preClickPath)
@@ -395,9 +422,418 @@ func TestVisionClick(t *testing.T) {
 	t.Logf("URL hash successfully updated to: %s", expectedHash)
 
 	// --- 7. Take Post-click Screenshot ---
-	// Save to project directory instead of temp
-	postClickPath := filepath.Join(screenshotDir, fmt.Sprintf("click_after_%s.png", uuid.NewString()))
+	postClickPath := filepath.Join(testScreenshotDir, "click_after.png") // Use shared dir and descriptive name
 	_, err = page.Screenshot(playwright.PageScreenshotOptions{Path: &postClickPath})
 	require.NoError(t, err, "Failed to take post-click screenshot")
 	t.Logf("Post-click screenshot saved to: %s", postClickPath)
+}
+
+// TestVisionDoubleClick verifies the ExecuteVisionDoubleClick service method.
+func TestVisionDoubleClick(t *testing.T) {
+	// Use the new setup function that provides a configured service and page
+	svc, boxID, contextID, pageID, page, cleanup := setupServiceWithVisionTestPage(t)
+	defer cleanup()
+
+	// --- Get shared output directory for this test run ---
+	testScreenshotDir := getTestRunScreenshotDir(t)
+
+	// --- 1. Define Target and Get Coordinates ---
+	buttonSelector := "#dblclick-btn" // Target the double-click button
+	buttonLocator := page.Locator(buttonSelector)
+	bbox, err := buttonLocator.BoundingBox()
+	require.NoError(t, err, "Failed to get bounding box for %s", buttonSelector)
+	require.NotNil(t, bbox, "Bounding box should not be nil for %s", buttonSelector)
+
+	clickX := bbox.X + bbox.Width/2
+	clickY := bbox.Y + bbox.Height/2
+
+	// --- 2. Take Pre-double-click Screenshot ---
+	preDblClickPath := filepath.Join(testScreenshotDir, "dblclick_before.png") // Use shared dir and descriptive name
+	_, err = page.Screenshot(playwright.PageScreenshotOptions{Path: &preDblClickPath})
+	require.NoError(t, err, "Failed to take pre-double-click screenshot")
+	t.Logf("Pre-double-click screenshot saved to: %s", preDblClickPath)
+
+	// --- 3. Setup Service (Handled by setupServiceWithVisionTestPage) ---
+	// svc, boxID, contextID, pageID are available
+
+	// --- 4. Execute Double Click Action ---
+	params := model.VisionDoubleClickParams{
+		X: int(clickX),
+		Y: int(clickY),
+		// Button and Delay options could be added here if needed
+	}
+	dblClickResult := svc.ExecuteVisionDoubleClick(boxID, contextID, pageID, params)
+
+	// --- 5. Assert Service Call Success ---
+	require.NotNil(t, dblClickResult, "ExecuteVisionDoubleClick returned nil result")
+	resultData, ok := dblClickResult.(model.VisionDoubleClickResult)
+	require.True(t, ok, "ExecuteVisionDoubleClick returned unexpected type: %T", dblClickResult)
+	assert.True(t, resultData.Success, "ExecuteVisionDoubleClick result.Success should be true")
+
+	// --- 6. Verify URL Hash Change ---
+	expectedHash := "#doubleClick-dblclick_btn" // See vision-test.html
+	require.Eventually(t, func() bool {
+		currentURL := page.URL()
+		return strings.HasSuffix(currentURL, expectedHash)
+	}, 5*time.Second, 100*time.Millisecond, "URL hash did not become '%s', current URL: %s", expectedHash, page.URL())
+	t.Logf("URL hash successfully updated to: %s", expectedHash)
+
+	// --- 7. Take Post-double-click Screenshot ---
+	postDblClickPath := filepath.Join(testScreenshotDir, "dblclick_after.png") // Use shared dir and descriptive name
+	_, err = page.Screenshot(playwright.PageScreenshotOptions{Path: &postDblClickPath})
+	require.NoError(t, err, "Failed to take post-double-click screenshot")
+	t.Logf("Post-double-click screenshot saved to: %s", postDblClickPath)
+}
+
+// TestVisionType verifies the ExecuteVisionType service method.
+func TestVisionType(t *testing.T) {
+	// Use the new setup function that provides a configured service and page
+	svc, boxID, contextID, pageID, page, cleanup := setupServiceWithVisionTestPage(t)
+	defer cleanup()
+
+	// --- Get shared output directory for this test run ---
+	testScreenshotDir := getTestRunScreenshotDir(t)
+
+	// --- 1. Define Target and Text ---
+	inputSelector := "#type-input"
+	typedText := "hello world"
+
+	// --- 2. Take Pre-type Screenshot ---
+	preTypePath := filepath.Join(testScreenshotDir, "type_before.png")
+	_, err := page.Screenshot(playwright.PageScreenshotOptions{Path: &preTypePath})
+	require.NoError(t, err, "Failed to take pre-type screenshot")
+	t.Logf("Pre-type screenshot saved to: %s", preTypePath)
+
+	// --- 3. Focus the input element first (good practice for typing) ---
+	err = page.Locator(inputSelector).Focus()
+	require.NoError(t, err, "Failed to focus input element %s", inputSelector)
+	t.Logf("Focused input element: %s", inputSelector)
+
+	// --- 4. Execute Type Action ---
+	params := model.VisionTypeParams{
+		Text: typedText,
+	}
+	typeResult := svc.ExecuteVisionType(boxID, contextID, pageID, params)
+
+	// --- 5. Assert Service Call Success ---
+	require.NotNil(t, typeResult, "ExecuteVisionType returned nil result")
+	resultData, ok := typeResult.(model.VisionTypeResult)
+	require.True(t, ok, "ExecuteVisionType returned unexpected type: %T", typeResult)
+	assert.True(t, resultData.Success, "ExecuteVisionType result.Success should be true")
+
+	// --- 6. Verify Input Value ---
+	inputValue, err := page.Locator(inputSelector).InputValue()
+	require.NoError(t, err, "Failed to get input value for %s", inputSelector)
+	assert.Equal(t, typedText, inputValue, "Input value should match typed text")
+	t.Logf("Input value verified: %s", inputValue)
+
+	// --- 7. Verify URL Hash Change ---
+	expectedHashSuffix := strings.ReplaceAll(typedText, " ", "_") // Convert space to underscore for hash
+	expectedHash := fmt.Sprintf("#type-%s", expectedHashSuffix)
+	require.Eventually(t, func() bool {
+		currentURL := page.URL()
+		return strings.HasSuffix(currentURL, expectedHash)
+	}, 5*time.Second, 100*time.Millisecond, "URL hash did not become '%s', current URL: %s", expectedHash, page.URL())
+	t.Logf("URL hash successfully updated to: %s", expectedHash)
+
+	// --- 8. Take Post-type Screenshot ---
+	postTypePath := filepath.Join(testScreenshotDir, "type_after.png")
+	_, err = page.Screenshot(playwright.PageScreenshotOptions{Path: &postTypePath})
+	require.NoError(t, err, "Failed to take post-type screenshot")
+	t.Logf("Post-type screenshot saved to: %s", postTypePath)
+}
+
+// TestVisionScroll verifies the ExecuteVisionScroll service method.
+// It now tests scrolling a specific element (#scroll-area) after moving the mouse into it.
+func TestVisionScroll(t *testing.T) {
+	// Use the new setup function that provides a configured service and page
+	svc, boxID, contextID, pageID, page, cleanup := setupServiceWithVisionTestPage(t)
+	defer cleanup()
+
+	// --- Get shared output directory for this test run ---
+	testScreenshotDir := getTestRunScreenshotDir(t)
+
+	// --- 1. Define Target Element and Scroll Amount ---
+	scrollElementSelector := "#scroll-area" // Assume this is the ID of the scrollable div
+	scrollY := 100                          // Scroll down by 100 pixels
+	scrollX := 0                            // No horizontal scroll
+
+	// --- 2. Locate Element and Calculate Target Coordinates ---
+	scrollLocator := page.Locator(scrollElementSelector)
+	bbox, err := scrollLocator.BoundingBox()
+	require.NoError(t, err, "Failed to get bounding box for %s", scrollElementSelector)
+	require.NotNil(t, bbox, "Bounding box should not be nil for %s", scrollElementSelector)
+	targetX := bbox.X + bbox.Width/2
+	targetY := bbox.Y + bbox.Height/2
+
+	// --- 3. Move Mouse into the Element ---
+	err = page.Mouse().Move(targetX, targetY)
+	require.NoError(t, err, "Failed to move mouse to %s (%f, %f)", scrollElementSelector, targetX, targetY)
+	t.Logf("Mouse moved into element: %s", scrollElementSelector)
+	// Add a small delay to ensure the move completes and potential hover effects trigger
+	time.Sleep(100 * time.Millisecond)
+
+	// --- 4. Take Pre-scroll Screenshot (after moving mouse) ---
+	preScrollPath := filepath.Join(testScreenshotDir, "scroll_element_before.png") // Update filename
+	_, err = page.Screenshot(playwright.PageScreenshotOptions{Path: &preScrollPath})
+	require.NoError(t, err, "Failed to take pre-scroll screenshot")
+	t.Logf("Pre-scroll screenshot saved to: %s", preScrollPath)
+
+	// --- 5. Execute Scroll Action (at current mouse position) ---
+	params := model.VisionScrollParams{
+		ScrollX: scrollX,
+		ScrollY: scrollY,
+		// X/Y are not strictly needed by the current Mouse.Wheel implementation in service,
+		// but setting them doesn't hurt.
+		X: int(targetX),
+		Y: int(targetY),
+	}
+	scrollResult := svc.ExecuteVisionScroll(boxID, contextID, pageID, params)
+
+	// --- 6. Assert Service Call Success ---
+	require.NotNil(t, scrollResult, "ExecuteVisionScroll returned nil result")
+
+	// Check if an error was returned and log it
+	if errResult, isError := scrollResult.(model.VisionErrorResult); isError {
+		t.Fatalf("ExecuteVisionScroll returned an error: %s", errResult.Error)
+	}
+
+	// Proceed with the type assertion now that we know it's not an error
+	resultData, ok := scrollResult.(model.VisionScrollResult)
+	require.True(t, ok, "ExecuteVisionScroll returned unexpected type: %T (expected VisionScrollResult)", scrollResult)
+	assert.True(t, resultData.Success, "ExecuteVisionScroll result.Success should be true")
+
+	// --- 7. Verify Element Scroll Position and URL Hash Change ---
+	time.Sleep(100 * time.Millisecond) // Delay for scroll event propagation
+
+	// Get the actual scrollTop of the element after the scroll action.
+	// Pass nil as the second argument for Evaluate as required by the signature
+	currentScrollYRaw, evalErr := scrollLocator.Evaluate("el => el.scrollTop", nil) // Evaluate element's scrollTop
+	require.NoError(t, evalErr, "Failed to evaluate %s.scrollTop", scrollElementSelector)
+	require.NotNil(t, currentScrollYRaw, "%s.scrollTop evaluation returned nil", scrollElementSelector)
+
+	// Handle different possible numeric types returned by Evaluate
+	var actualScrollY float64
+	switch v := currentScrollYRaw.(type) {
+	case float64:
+		actualScrollY = v
+	case int:
+		actualScrollY = float64(v)
+	case int64:
+		actualScrollY = float64(v)
+	// Add other potential types like json.Number if necessary
+	default:
+		t.Fatalf("%s.scrollTop evaluation returned unexpected type: %T", scrollElementSelector, currentScrollYRaw)
+	}
+
+	// Use GreaterOrEqual because scroll amount might not be exact
+	require.GreaterOrEqual(t, actualScrollY, float64(scrollY)*0.9, "Actual element scrollTop (%f) should be close to the scrolled amount (%d)", actualScrollY, scrollY)
+
+	// Check the URL hash. The JS in vision-test.html seems to replace hyphens in the element ID with underscores.
+	elementIDPart := strings.ReplaceAll(scrollElementSelector[1:], "-", "_")        // Replace hyphen with underscore
+	expectedHash := fmt.Sprintf("#scroll-%s_%d", elementIDPart, int(actualScrollY)) // Use modified ID part
+
+	require.Eventually(t, func() bool {
+		currentURL := page.URL()
+		return strings.HasSuffix(currentURL, expectedHash)
+	}, 5*time.Second, 100*time.Millisecond, "URL hash did not end with '%s', current URL: %s", expectedHash, page.URL())
+	t.Logf("URL hash successfully updated, ending with: %s", expectedHash)
+
+	// --- 8. Take Post-scroll Screenshot ---
+	postScrollPath := filepath.Join(testScreenshotDir, "scroll_element_after.png") // Update filename
+	_, err = page.Screenshot(playwright.PageScreenshotOptions{Path: &postScrollPath})
+	require.NoError(t, err, "Failed to take post-scroll screenshot")
+	t.Logf("Post-scroll screenshot saved to: %s", postScrollPath)
+}
+
+// TestVisionDrag verifies the ExecuteVisionDrag service method.
+func TestVisionDrag(t *testing.T) {
+	// Use the new setup function that provides a configured service and page
+	svc, boxID, contextID, pageID, page, cleanup := setupServiceWithVisionTestPage(t)
+	defer cleanup()
+
+	// --- Get shared output directory for this test run ---
+	testScreenshotDir := getTestRunScreenshotDir(t)
+
+	// --- 1. Define Target and Calculate Coordinates ---
+	dragSourceSelector := "#drag-source"
+	dragSourceLocator := page.Locator(dragSourceSelector)
+	bbox, err := dragSourceLocator.BoundingBox()
+	require.NoError(t, err, "Failed to get bounding box for %s", dragSourceSelector)
+	require.NotNil(t, bbox, "Bounding box should not be nil for %s", dragSourceSelector)
+
+	startX := int(bbox.X + bbox.Width/2)
+	startY := int(bbox.Y + bbox.Height/2)
+	endX := startX + 50 // Drag 50px right
+	endY := startY + 50 // Drag 50px down
+
+	// --- 2. Take Pre-drag Screenshot ---
+	preDragPath := filepath.Join(testScreenshotDir, "drag_before.png")
+	_, err = page.Screenshot(playwright.PageScreenshotOptions{Path: &preDragPath})
+	require.NoError(t, err, "Failed to take pre-drag screenshot")
+	t.Logf("Pre-drag screenshot saved to: %s", preDragPath)
+
+	// --- 3. Execute Drag Action ---
+	params := model.VisionDragParams{
+		Path: []model.Coordinate{
+			{X: startX, Y: startY}, // Start point
+			{X: endX, Y: endY},     // End point
+		},
+	}
+	dragResult := svc.ExecuteVisionDrag(boxID, contextID, pageID, params)
+
+	// --- 4. Assert Service Call Success ---
+	require.NotNil(t, dragResult, "ExecuteVisionDrag returned nil result")
+	resultData, ok := dragResult.(model.VisionDragResult)
+	require.True(t, ok, "ExecuteVisionDrag returned unexpected type: %T", dragResult)
+	assert.True(t, resultData.Success, "ExecuteVisionDrag result.Success should be true")
+
+	// --- 5. Verify URL Hash Change (indicates dragEnd event fired) ---
+	// The JS replaces non-alphanumeric chars in details with '_' -> "#dragEnd-at_X_Y"
+	expectedHash := fmt.Sprintf("#dragEnd-at_%d_%d", endX, endY)
+	require.Eventually(t, func() bool {
+		currentURL := page.URL()
+		// The hash might contain extra characters from the replacement logic, check suffix
+		return strings.HasSuffix(currentURL, expectedHash)
+	}, 5*time.Second, 100*time.Millisecond, "URL hash did not end with '%s', current URL: %s", expectedHash, page.URL())
+	t.Logf("URL hash successfully updated, ending with: %s", expectedHash)
+
+	// --- 6. Take Post-drag Screenshot ---
+	postDragPath := filepath.Join(testScreenshotDir, "drag_after.png")
+	_, err = page.Screenshot(playwright.PageScreenshotOptions{Path: &postDragPath})
+	require.NoError(t, err, "Failed to take post-drag screenshot")
+	t.Logf("Post-drag screenshot saved to: %s", postDragPath)
+}
+
+// TestVisionKeyPress verifies the ExecuteVisionKeyPress service method
+func TestVisionKeyPress(t *testing.T) {
+	// Use the new setup function that provides a configured service and page
+	svc, boxID, contextID, pageID, page, cleanup := setupServiceWithVisionTestPage(t)
+	defer cleanup()
+
+	// --- Get shared output directory for this test run ---
+	testScreenshotDir := getTestRunScreenshotDir(t)
+
+	// --- 1. Define Target Element and Keys ---
+	pressAreaSelector := "#press-area"
+	keysToPress := []string{"Control+Shift+Alt+Meta+A"}
+
+	// --- 2. Take Pre-press Screenshot ---
+	prePressPath := filepath.Join(testScreenshotDir, "keypress_before.png")
+	_, err := page.Screenshot(playwright.PageScreenshotOptions{Path: &prePressPath})
+	require.NoError(t, err, "Failed to take pre-keypress screenshot")
+	t.Logf("Pre-keypress screenshot saved to: %s", prePressPath)
+
+	// --- 3. Focus the target element ---
+	pressAreaLocator := page.Locator(pressAreaSelector)
+	err = pressAreaLocator.Focus()
+	require.NoError(t, err, "Failed to focus element %s", pressAreaSelector)
+	t.Logf("Focused element: %s", pressAreaSelector)
+
+	// --- 4. Execute Key Press Action ---
+	params := model.VisionKeyPressParams{
+		Keys: keysToPress,
+	}
+	keyPressResult := svc.ExecuteVisionKeyPress(boxID, contextID, pageID, params)
+
+	// --- 5. Assert Service Call Success ---
+	require.NotNil(t, keyPressResult, "ExecuteVisionKeyPress returned nil result")
+	resultData, ok := keyPressResult.(model.VisionKeyPressResult)
+	require.True(t, ok, "ExecuteVisionKeyPress returned unexpected type: %T", keyPressResult)
+	assert.True(t, resultData.Success, "ExecuteVisionKeyPress result.Success should be true")
+
+	// --- 6. Verify UI State Change (Last Action Display and URL Hash) ---
+	// According to vision-test.html logic, the hash reflects the last key press event.
+	// For "Control+Shift+Alt+Meta+A", the JS should generate:
+	// Mac:   Display "keyPress (⌃+⌥+⇧+⌘+A)", Hash #keyPress-⌃_⌥_⇧_⌘_A
+	// Other: Display "keyPress (Ctrl+Alt+Shift+Meta+A)", Hash #keyPress-Ctrl_Alt_Shift_Meta_A
+	// The JS replaces non-alphanumeric chars (excluding symbols ⌃⌥⇧⌘) with '_'
+	// Assuming test runs on macOS based on user context
+	expectedDisplayText := "(⌃+⌥+⇧+⌘+A)"
+	// Define the raw, unescaped hash suffix expected from the JS logic
+	expectedRawHashSuffix := "keyPress-⌃_⌥_⇧_⌘_A"
+	// URL-encode the raw suffix to match how the browser represents it in the URL fragment
+	expectedEncodedHash := "#" + url.PathEscape(expectedRawHashSuffix)
+
+	// Verify the displayed text reflects the combination
+	require.Eventually(t, func() bool {
+		lastActionText, err := page.Locator("#last-action").TextContent()
+		if err != nil {
+			t.Logf("Error getting text content: %v", err)
+			return false
+		}
+		// Check if the text contains the representation of the last key press
+		return strings.Contains(lastActionText, expectedDisplayText) && strings.Contains(lastActionText, "keyPress") // Updated check
+	}, 5*time.Second, 100*time.Millisecond, "Last action display did not update correctly for combo key press. Expected to contain: %s, Got: %s", expectedDisplayText) // Updated message
+	t.Logf("Last action display updated correctly.")
+
+	// Verify the URL hash based on the last key press ('Enter')
+	require.Eventually(t, func() bool {
+		currentURL := page.URL()
+		// Compare the suffix with the *encoded* expected hash
+		return strings.HasSuffix(currentURL, expectedEncodedHash)
+	}, 5*time.Second, 100*time.Millisecond, "URL hash did not end with '%s', current URL: %s", expectedEncodedHash, page.URL()) // Use encoded hash in message
+	t.Logf("URL hash successfully updated, ending with: %s", expectedEncodedHash) // Log the encoded hash
+
+	// --- 7. Take Post-press Screenshot ---
+	postPressPath := filepath.Join(testScreenshotDir, "keypress_after.png")
+	_, err = page.Screenshot(playwright.PageScreenshotOptions{Path: &postPressPath})
+	require.NoError(t, err, "Failed to take post-keypress screenshot")
+	t.Logf("Post-keypress screenshot saved to: %s", postPressPath)
+}
+
+// TestVisionMove verifies the ExecuteVisionMove service method.
+func TestVisionMove(t *testing.T) {
+	// Use the new setup function that provides a configured service and page
+	svc, boxID, contextID, pageID, page, cleanup := setupServiceWithVisionTestPage(t)
+	defer cleanup()
+
+	// --- Get shared output directory for this test run ---
+	testScreenshotDir := getTestRunScreenshotDir(t)
+
+	// --- 1. Define Target Coordinates ---
+	// Let's move the mouse to the center of the 'drag-source' element
+	targetSelector := "#drag-source"
+	targetLocator := page.Locator(targetSelector)
+	bbox, err := targetLocator.BoundingBox()
+	require.NoError(t, err, "Failed to get bounding box for %s", targetSelector)
+	require.NotNil(t, bbox, "Bounding box should not be nil for %s", targetSelector)
+
+	targetX := int(bbox.X + bbox.Width/2)
+	targetY := int(bbox.Y + bbox.Height/2)
+
+	// --- 2. Take Pre-move Screenshot ---
+	preMovePath := filepath.Join(testScreenshotDir, "move_before.png")
+	_, err = page.Screenshot(playwright.PageScreenshotOptions{Path: &preMovePath})
+	require.NoError(t, err, "Failed to take pre-move screenshot")
+	t.Logf("Pre-move screenshot saved to: %s", preMovePath)
+
+	// --- 3. Execute Move Action ---
+	params := model.VisionMoveParams{
+		X: targetX,
+		Y: targetY,
+	}
+	moveResult := svc.ExecuteVisionMove(boxID, contextID, pageID, params)
+
+	// --- 4. Assert Service Call Success ---
+	require.NotNil(t, moveResult, "ExecuteVisionMove returned nil result")
+	resultData, ok := moveResult.(model.VisionMoveResult)
+	require.True(t, ok, "ExecuteVisionMove returned unexpected type: %T", moveResult)
+	assert.True(t, resultData.Success, "ExecuteVisionMove result.Success should be true")
+
+	// --- 5. Verify URL Hash Change (indicates mousemove event fired at location) ---
+	// The JS updates hash like #mouseMove-at_X_Y
+	expectedHash := fmt.Sprintf("#mouseMove-at_%d_%d", targetX, targetY)
+	require.Eventually(t, func() bool {
+		currentURL := page.URL()
+		// Use HasSuffix as events might fire rapidly, we care about the final state
+		return strings.HasSuffix(currentURL, expectedHash)
+	}, 5*time.Second, 100*time.Millisecond, "URL hash did not end with '%s', current URL: %s", expectedHash, page.URL())
+	t.Logf("URL hash successfully updated, ending with: %s", expectedHash)
+
+	// --- 6. Take Post-move Screenshot ---
+	postMovePath := filepath.Join(testScreenshotDir, "move_after.png")
+	_, err = page.Screenshot(playwright.PageScreenshotOptions{Path: &postMovePath})
+	require.NoError(t, err, "Failed to take post-move screenshot")
+	t.Logf("Post-move screenshot saved to: %s", postMovePath)
 }

--- a/packages/api-server/internal/browser/testdata/vision-test.html
+++ b/packages/api-server/internal/browser/testdata/vision-test.html
@@ -62,13 +62,14 @@
         let isDragging = false;
         let lastMoveTimestamp = 0;
         const moveUpdateThrottle = 50; // ms
+        let ignoreNextBodyClick = false;
 
         function updateLastAction(actionName, details = '') {
             const message = `Last action: ${actionName}${details ? ` (${details})` : ''}`;
             console.log(message); // Log to console for debugging tests
             lastActionDisplay.textContent = message;
-            // Update URL hash - simple way to check state from Playwright
-            window.location.hash = `${actionName}${details ? `-${details.replace(/[^a-zA-Z0-9]/g, '_')}` : ''}`;
+            // Update URL hash - allow specific symbols (⌃⌥⇧⌘) in addition to alphanumerics
+            window.location.hash = `${actionName}${details ? `-${details.replace(/[^a-zA-Z0-9⌃⌥⇧⌘]/g, '_')}` : ''}`;
         }
 
         // --- Event Listeners ---
@@ -89,6 +90,9 @@
         });
          // Catch clicks elsewhere too
         document.body.addEventListener('click', (e) => {
+            if (ignoreNextBodyClick) {
+                return;
+            }
             if (e.target !== clickBtn && e.target !== dblClickBtn && e.target !== coordClickArea && !coordClickArea.contains(e.target) ) {
                 updateLastAction('click', `body:${e.clientX},${e.clientY}`);
             }
@@ -119,6 +123,8 @@
                 dragSource.style.cursor = 'grab';
                 updateLastAction('dragEnd', `at:${e.clientX},${e.clientY}`);
                 console.log('Drag ended');
+                ignoreNextBodyClick = true;
+                setTimeout(() => { ignoreNextBodyClick = false; }, 0); 
             }
         });
          // Prevent default drag behavior which can interfere
@@ -127,41 +133,95 @@
 
         // vision.keyPress
         pressArea.addEventListener('keydown', (e) => {
-            // Don't update for modifier keys themselves if they are the *only* key pressed
-            if (!['Shift', 'Control', 'Alt', 'Meta'].includes(e.key)) {
-                 updateLastAction('keyPress', e.key);
+            const combo = [];
+            const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+            if (e.ctrlKey) combo.push(isMac ? '⌃' : 'Ctrl');
+            if (e.altKey) combo.push(isMac ? '⌥' : 'Alt');
+            if (e.shiftKey) combo.push(isMac ? '⇧' : 'Shift');
+            if (e.metaKey) combo.push(isMac ? '⌘' : 'Meta');
+            
+            // Use e.code to get the physical key, ignoring Option/Alt effects
+            const keyCode = e.code;
+            // Determine if the pressed key is a modifier key itself
+            const isModifier = ['ControlLeft', 'ControlRight', 'AltLeft', 'AltRight', 'ShiftLeft', 'ShiftRight', 'MetaLeft', 'MetaRight'].includes(keyCode);
+
+            if (!isModifier) {
+                // Clean up the code (e.g., KeyJ -> J, Digit1 -> 1)
+                let displayKey = keyCode.replace(/^(Key|Digit)/, '');
+                combo.push(displayKey); 
+            }
+            
+            // If only modifiers were pressed, use e.key as fallback (e.g., show 'Shift')
+            if (combo.length === 0 && ['Control', 'Alt', 'Shift', 'Meta'].includes(e.key)){
+                combo.push(e.key);
+            }
+
+            if (combo.length > 0) {
+                updateLastAction('keyPress', combo.join('+'));
             }
         });
-         // Also listen globally in case focus isn't on the pressArea
-         document.addEventListener('keydown', (e) => {
-             if (document.activeElement !== pressArea && document.activeElement !== typeInput) {
-                 if (!['Shift', 'Control', 'Alt', 'Meta'].includes(e.key)) {
-                    updateLastAction('keyPress', `global:${e.key}`);
-                 }
-             }
-         });
+        
+        // Also listen globally in case focus isn't on the pressArea
+        document.addEventListener('keydown', (e) => {
+            if (document.activeElement !== pressArea && document.activeElement !== typeInput) {
+                const combo = [];
+                const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+                if (e.ctrlKey) combo.push(isMac ? '⌃' : 'Ctrl');
+                if (e.altKey) combo.push(isMac ? '⌥' : 'Alt');
+                if (e.shiftKey) combo.push(isMac ? '⇧' : 'Shift');
+                if (e.metaKey) combo.push(isMac ? '⌘' : 'Meta');
 
-        // vision.move
-        moveArea.addEventListener('mousemove', (e) => {
+                const keyCode = e.code;
+                const isModifier = ['ControlLeft', 'ControlRight', 'AltLeft', 'AltRight', 'ShiftLeft', 'ShiftRight', 'MetaLeft', 'MetaRight'].includes(keyCode);
+
+                if (!isModifier) {
+                    let displayKey = keyCode.replace(/^(Key|Digit)/, '');
+                    combo.push(displayKey);
+                }
+
+                if (combo.length === 0 && ['Control', 'Alt', 'Shift', 'Meta'].includes(e.key)){
+                    combo.push(e.key);
+                }
+
+                if (combo.length > 0) {
+                    updateLastAction('keyPress', `global:${combo.join('+')}`);
+                }
+            }
+        });
+
+        // vision.move - Listener moved to document.body
+        // moveArea.addEventListener('mousemove', (e) => { // Removed listener from specific element
+        document.body.addEventListener('mousemove', (e) => { // Added listener to body
             const now = Date.now();
             // Throttle updates slightly to avoid spamming hash changes
-            if (now - lastMoveTimestamp > moveUpdateThrottle) {
-                const rect = moveArea.getBoundingClientRect();
-                const x = Math.round(e.clientX - rect.left);
-                const y = Math.round(e.clientY - rect.top);
-                updateLastAction('move', `move-area:${x},${y}`);
+            // Only update if not currently dragging to avoid conflict with drag events
+            if (!isDragging && now - lastMoveTimestamp > moveUpdateThrottle) {
+                // const rect = moveArea.getBoundingClientRect(); // No longer relevant for body
+                // const x = Math.round(e.clientX - rect.left);
+                // const y = Math.round(e.clientY - rect.top);
+
+                // Get coordinates relative to the viewport
+                const x = Math.round(e.clientX);
+                const y = Math.round(e.clientY);
+
+                // updateLastAction('move', `move-area:${x},${y}`); // Old update action
+
+                // Update hash to match the format expected by TestVisionMove
+                const details = `at_${x}_${y}`;
+                updateLastAction('mouseMove', details);
+
                 lastMoveTimestamp = now;
             }
         });
 
         // vision.scroll (specific element)
         scrollArea.addEventListener('scroll', () => {
-             updateLastAction('scroll', `scroll-area:${scrollArea.scrollTop}`);
+            updateLastAction('scroll', `scroll-area:${scrollArea.scrollTop}`);
         });
 
         // vision.scroll (window)
         window.addEventListener('scroll', () => {
-             updateLastAction('scroll', `window:${window.scrollY}`);
+            updateLastAction('scroll', `window:${window.scrollY}`);
         });
 
         // Initial state


### PR DESCRIPTION
- Add ANSI color variables to Makefile for better terminal output
- Introduce shared screenshot directory for vision tests
- Update vision test cases to use new screenshot directory
- Modify event handling in vision-test.html for better tracking
- Enhance mouse movement and drag actions in browser service

```bash
❯ make serve-vision-test
Serving vision-test.html at: http://localhost:8070/vision-test.html
Press Ctrl+C to stop the server.
Serving HTTP on 127.0.0.1 port 8070 (http://127.0.0.1:8070/) ...
```
<img width="772" alt="image" src="https://github.com/user-attachments/assets/502971b7-ab15-48d3-b33f-7ea79040a2d6" />
