### PR TITLE
⭐️ feat: Box image management

### DIFF
--- a/packages/api-server/internal/box/api/routes.go
+++ b/packages/api-server/internal/box/api/routes.go
@@ -23,7 +23,10 @@ func RegisterRoutes(ws *restful.WebService, boxHandler *BoxHandler) {
 	ws.Route(ws.POST("/boxes").To(boxHandler.CreateBox).
 		Doc("create a box").
 		Reads(model.BoxCreateParams{}).
+		Produces("application/json", "application/json-stream").
+		Param(ws.QueryParameter("timeout", "timeout duration for image pull (e.g. 30s, 1m)").DataType("string").Required(false)).
 		Returns(201, "Created", model.Box{}).
+		Returns(202, "Accepted", model.BoxError{}).
 		Returns(400, "Bad Request", model.BoxError{}).
 		Returns(500, "Internal Server Error", model.BoxError{}))
 
@@ -118,5 +121,15 @@ func RegisterRoutes(ws *restful.WebService, boxHandler *BoxHandler) {
 		Returns(200, "OK", nil).
 		Returns(400, "Bad Request", model.BoxError{}).
 		Returns(404, "Not Found", model.BoxError{}).
+		Returns(500, "Internal Server Error", model.BoxError{}))
+
+	// Image management operations
+	ws.Route(ws.POST("/boxes/images/update").To(boxHandler.UpdateBoxImage).
+		Doc("updates docker images, pulling latest and removing outdated versions").
+		Reads(model.ImageUpdateParams{}).
+		Produces("application/json", "application/json-stream").
+		Param(ws.QueryParameter("imageName", "image name to update (default: babelcloud/gbox-playwright)").DataType("string").Required(false)).
+		Param(ws.QueryParameter("dryRun", "if true, only reports planned actions without executing them").DataType("boolean").Required(false)).
+		Returns(200, "OK", model.ImageUpdateResponse{}).
 		Returns(500, "Internal Server Error", model.BoxError{}))
 }

--- a/packages/api-server/internal/box/service/impl/docker/images.go
+++ b/packages/api-server/internal/box/service/impl/docker/images.go
@@ -1,0 +1,444 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
+
+	"github.com/babelcloud/gbox/packages/api-server/config"
+	model "github.com/babelcloud/gbox/packages/api-server/pkg/box"
+	"github.com/babelcloud/gbox/packages/api-server/pkg/logger"
+)
+
+// Constants for image actions
+const (
+	ActionPull   = "pull"   // Pull the image
+	ActionDelete = "delete" // Delete the image
+	ActionKeep   = "keep"   // Keep the image as is
+)
+
+// DefaultImageName is the default image name used when none is specified
+const DefaultImageName = "babelcloud/gbox-playwright"
+
+// Logger instance
+var log = logger.New()
+
+// Image status tracking data structure
+type imageStatus struct {
+	pulling   bool
+	done      chan struct{}
+	succeeded bool
+}
+
+// Global image status tracker
+var (
+	// Mutex for protecting image status access
+	imageLock sync.Mutex
+	// Tracks images currently being pulled
+	imageStatuses = make(map[string]*imageStatus)
+)
+
+// CheckImageExists checks if an image exists locally
+func (s *Service) CheckImageExists(ctx context.Context, params *model.BoxCreateParams) (bool, string) {
+	image := params.Image
+	if image == "" {
+		image = DefaultImageName
+	}
+
+	// Use CheckImageTag to get standardized image name
+	imageWithTag := config.CheckImageTag(image)
+
+	// Parse repository and tag
+	repo, tag, ok := parseImageTag(imageWithTag)
+	if !ok {
+		return false, imageWithTag
+	}
+
+	// Recombine to ensure consistent format
+	imageWithTag = fmt.Sprintf("%s:%s", repo, tag)
+
+	// Try to check if image exists
+	_, _, err := s.client.ImageInspectWithRaw(ctx, imageWithTag)
+	return err == nil, imageWithTag
+}
+
+// EnsureImagePulling ensures an image is being pulled, starting the pull process if not already in progress
+func (s *Service) EnsureImagePulling(ctx context.Context, imageName string) {
+	imageLock.Lock()
+	status, exists := imageStatuses[imageName]
+
+	// If image is not being pulled, start pulling
+	if !exists || !status.pulling {
+		log.Infof("Starting async image pull for %s", imageName)
+		newStatus := &imageStatus{
+			pulling: true,
+			done:    make(chan struct{}),
+		}
+		imageStatuses[imageName] = newStatus
+		imageLock.Unlock()
+
+		// Start async pull
+		go func() {
+			// Create a new context with cancel function to avoid parent context cancellation affecting the pull
+			pullCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			log.Infof("Async image pull for %s started", imageName)
+
+			// Perform image pull - no progress output as this is a background operation
+			result := s.pullImage(pullCtx, imageName)
+
+			// Update pull status
+			imageLock.Lock()
+			if status, ok := imageStatuses[imageName]; ok {
+				status.pulling = false
+				status.succeeded = result.success
+				close(status.done)
+			}
+			imageLock.Unlock()
+
+			if result.success {
+				log.Infof("Async image pull for %s completed successfully", imageName)
+			} else {
+				log.Warnf("Async image pull for %s failed: %s", imageName, result.message)
+			}
+		}()
+	} else {
+		// Image already being pulled, release lock and return
+		log.Infof("Image %s is already being pulled, skipping duplicate pull", imageName)
+		imageLock.Unlock()
+	}
+}
+
+// WaitForImagePull returns a channel that is closed when image pull completes
+func (s *Service) WaitForImagePull(imageName string) <-chan struct{} {
+	imageLock.Lock()
+	defer imageLock.Unlock()
+
+	status, exists := imageStatuses[imageName]
+	if !exists {
+		// If no pull record exists, create a closed channel to indicate completion
+		log.Infof("No active pull found for image %s, returning completed channel", imageName)
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+
+	if !status.pulling {
+		// Pull has already completed, check if successful
+		if status.succeeded {
+			log.Infof("Image %s pull already completed successfully", imageName)
+		} else {
+			log.Warnf("Image %s pull completed but failed", imageName)
+		}
+	} else {
+		log.Infof("Waiting for image %s pull to complete", imageName)
+	}
+
+	return status.done
+}
+
+// prepareImageUpdate does common setup for image update operations
+func (s *Service) prepareImageUpdate(ctx context.Context, params *model.ImageUpdateParams) (*model.ImageUpdateResponse, string, string, []image.Summary, error) {
+	response := &model.ImageUpdateResponse{
+		Images: []model.ImageInfo{},
+	}
+
+	// if imageReference is not set, use default image name
+	image := params.ImageReference
+	if image == "" {
+		image = DefaultImageName
+	}
+
+	// use CheckImageTag to parse image tag
+	imageWithTag := config.CheckImageTag(image)
+
+	// parse repo and tag from imageWithTag
+	repo, tag, ok := parseImageTag(imageWithTag)
+	if !ok {
+		response.ErrorMessage = fmt.Sprintf("Can't find latest tag for image %s, you may provide a image not supported by gbox or server side image tag is not set", image)
+		return response, "", "", nil, nil
+	}
+
+	// First list all relevant images to ensure we don't miss any outdated ones
+	filterArgs := filters.NewArgs()
+	filterArgs.Add("reference", repo+":*")
+
+	images, err := s.client.ImageList(ctx, types.ImageListOptions{
+		Filters: filterArgs,
+	})
+	if err != nil {
+		response.ErrorMessage = fmt.Sprintf("Failed to list local images: %v", err)
+		return response, "", "", nil, err
+	}
+
+	return response, repo, tag, images, nil
+}
+
+// UpdateBoxImage implements the BoxService interface method for updating images
+func (s *Service) UpdateBoxImage(ctx context.Context, params *model.ImageUpdateParams) (*model.ImageUpdateResponse, error) {
+	response, repo, tag, images, err := s.prepareImageUpdate(ctx, params)
+	if err != nil || repo == "" {
+		return response, err
+	}
+
+	imageWithTag := fmt.Sprintf("%s:%s", repo, tag)
+
+	// Process target image
+	targetImageInfo, targetImageId := s.processTargetImage(ctx, repo, tag, imageWithTag, params.DryRun)
+	response.Images = append(response.Images, targetImageInfo)
+
+	// Process existing images (find outdated versions)
+	s.processOutdatedImages(ctx, images, repo, tag, targetImageId, params.DryRun, params.Force, &response.Images)
+
+	return response, nil
+}
+
+// UpdateBoxImageWithProgress implements the BoxService interface method for updating images with progress streaming
+func (s *Service) UpdateBoxImageWithProgress(ctx context.Context, params *model.ImageUpdateParams, progressWriter io.Writer) (*model.ImageUpdateResponse, error) {
+	response, repo, tag, images, err := s.prepareImageUpdate(ctx, params)
+	if err != nil || repo == "" {
+		return response, err
+	}
+
+	imageWithTag := fmt.Sprintf("%s:%s", repo, tag)
+
+	// Process target image with progress reporting
+	targetImageInfo, targetImageId := s.processTargetImageWithProgress(ctx, repo, tag, imageWithTag, params.DryRun, progressWriter)
+	response.Images = append(response.Images, targetImageInfo)
+
+	// Process existing images (find outdated versions)
+	s.processOutdatedImages(ctx, images, repo, tag, targetImageId, params.DryRun, params.Force, &response.Images)
+
+	return response, nil
+}
+
+// processTargetImage handles checking, pulling and preparing info for the target image
+func (s *Service) processTargetImage(ctx context.Context, repo string, tag string, imageWithTag string, dryRun bool) (model.ImageInfo, string) {
+	return s.processTargetImageInternal(ctx, repo, tag, imageWithTag, dryRun, nil)
+}
+
+// processTargetImageWithProgress handles checking, pulling and preparing info for the target image with progress reporting
+func (s *Service) processTargetImageWithProgress(ctx context.Context, repo string, tag string, imageWithTag string, dryRun bool, progressWriter io.Writer) (model.ImageInfo, string) {
+	// Write initial status to client before processing
+	initialStatus := model.ProgressUpdate{
+		Status:  model.ProgressStatusPrepare,
+		Message: fmt.Sprintf("Preparing to pull image: %s", imageWithTag),
+	}
+	encoder := json.NewEncoder(progressWriter)
+	encoder.Encode(initialStatus)
+
+	return s.processTargetImageInternal(ctx, repo, tag, imageWithTag, dryRun, progressWriter)
+}
+
+// processTargetImageInternal contains the shared logic between processTargetImage and processTargetImageWithProgress
+func (s *Service) processTargetImageInternal(ctx context.Context, repo string, tag string, imageWithTag string, dryRun bool, progressWriter io.Writer) (model.ImageInfo, string) {
+	targetImageInfo := model.ImageInfo{
+		Repository: repo,
+		Tag:        tag,
+	}
+
+	// Check if target image exists locally
+	targetImage, _, err := s.client.ImageInspectWithRaw(ctx, imageWithTag)
+
+	// Image exists locally
+	if err == nil {
+		targetImageInfo.Status = model.ImageStatusUpToDate
+		targetImageInfo.ImageID = targetImage.ID
+		targetImageInfo.Action = ActionKeep
+		return targetImageInfo, targetImage.ID
+	}
+
+	// Image doesn't exist locally
+	targetImageInfo.Status = model.ImageStatusMissing
+	targetImageInfo.Action = ActionPull
+
+	if dryRun {
+		return targetImageInfo, ""
+	}
+
+	// Pull the target image with or without progress
+	var pullResult pullResult
+	if progressWriter != nil {
+		pullResult = s.pullImageWithProgress(ctx, imageWithTag, progressWriter)
+	} else {
+		pullResult = s.pullImage(ctx, imageWithTag)
+	}
+
+	if pullResult.success {
+		targetImageInfo.Status = model.ImageStatusUpToDate
+		targetImageInfo.ImageID = pullResult.imageID
+		return targetImageInfo, pullResult.imageID
+	}
+
+	return targetImageInfo, ""
+}
+
+// pullResult contains the result of an image pull operation
+type pullResult struct {
+	success bool
+	imageID string
+	message string
+}
+
+// pullImage pulls an image and returns the result
+func (s *Service) pullImage(ctx context.Context, imageWithTag string) pullResult {
+	return s.pullImageInternal(ctx, imageWithTag, types.ImagePullOptions{}, nil)
+}
+
+// pullImageWithProgress pulls an image and streams progress information to the writer
+func (s *Service) pullImageWithProgress(ctx context.Context, imageWithTag string, progressWriter io.Writer) pullResult {
+	return s.pullImageInternal(ctx, imageWithTag, types.ImagePullOptions{}, progressWriter)
+}
+
+// pullImageInternal contains the shared logic for pulling images with optional progress reporting
+func (s *Service) pullImageInternal(ctx context.Context, imageWithTag string, pullOptions types.ImagePullOptions, progressWriter io.Writer) pullResult {
+	reader, err := s.client.ImagePull(ctx, imageWithTag, pullOptions)
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to pull: %v", err)
+
+		// Write error to client if we have a progress writer
+		if progressWriter != nil {
+			errorStatus := model.ProgressUpdate{
+				Status: model.ProgressStatusError,
+				Error:  errMsg,
+			}
+			encoder := json.NewEncoder(progressWriter)
+			encoder.Encode(errorStatus)
+		}
+
+		return pullResult{
+			success: false,
+			message: errMsg,
+		}
+	}
+	defer reader.Close()
+
+	// Process the pull based on whether we need to stream progress
+	var processErr error
+	if progressWriter != nil {
+		processErr = ProcessPullProgress(reader, progressWriter)
+	} else {
+		_, processErr = WaitForResponse(reader)
+	}
+
+	if processErr != nil {
+		// Write error to client if we have a progress writer
+		if progressWriter != nil {
+			errorStatus := model.ProgressUpdate{
+				Status: model.ProgressStatusError,
+				Error:  fmt.Sprintf("Error during pull: %v", processErr),
+			}
+			encoder := json.NewEncoder(progressWriter)
+			encoder.Encode(errorStatus)
+		}
+		return pullResult{
+			success: false,
+			message: fmt.Sprintf("Error during pull: %v", processErr),
+		}
+	}
+
+	// Try to get the ID of the pulled image
+	pulledImg, _, err := s.client.ImageInspectWithRaw(ctx, imageWithTag)
+	if err != nil {
+		successMsg := "Successfully pulled, but couldn't retrieve image ID"
+
+		// Send completion status if we have a progress writer
+		if progressWriter != nil {
+			completeStatus := model.ProgressUpdate{
+				Status:  model.ProgressStatusComplete,
+				Message: successMsg,
+			}
+			encoder := json.NewEncoder(progressWriter)
+			encoder.Encode(completeStatus)
+		}
+
+		return pullResult{
+			success: true,
+			message: successMsg,
+		}
+	}
+
+	// Send completion status with image ID if we have a progress writer
+	if progressWriter != nil {
+		completeStatus := model.ProgressUpdate{
+			Status:  model.ProgressStatusComplete,
+			Message: "Successfully pulled image",
+			ImageID: pulledImg.ID,
+		}
+		encoder := json.NewEncoder(progressWriter)
+		encoder.Encode(completeStatus)
+	}
+
+	return pullResult{
+		success: true,
+		imageID: pulledImg.ID,
+		message: "Successfully pulled",
+	}
+}
+
+// processOutdatedImages processes existing images and handles outdated ones
+func (s *Service) processOutdatedImages(ctx context.Context, images []image.Summary, repo string, currentTag string, targetImageId string, dryRun bool, force bool, resultImages *[]model.ImageInfo) {
+	for _, img := range images {
+		// Skip target image as we already added it
+		if targetImageId != "" && img.ID == targetImageId {
+			continue
+		}
+
+		for _, imgTag := range img.RepoTags {
+			imgRepo, imgTagValue, ok := parseImageTag(imgTag)
+			if !ok {
+				continue // Skip invalid tags
+			}
+
+			// Only process images with same repo but different tags
+			if imgRepo == repo && imgTagValue != currentTag {
+				outdatedImage := model.ImageInfo{
+					ImageID:    img.ID,
+					Repository: imgRepo,
+					Tag:        imgTagValue,
+					Status:     model.ImageStatusOutdated,
+					Action:     ActionDelete,
+				}
+
+				if !dryRun {
+					s.removeOutdatedImage(ctx, img.ID, &outdatedImage, force)
+				}
+
+				*resultImages = append(*resultImages, outdatedImage)
+			}
+		}
+	}
+}
+
+// removeOutdatedImage attempts to remove an outdated image
+func (s *Service) removeOutdatedImage(ctx context.Context, imageID string, imageInfo *model.ImageInfo, force bool) error {
+	_, err := s.client.ImageRemove(ctx, imageID, types.ImageRemoveOptions{
+		Force:         force,
+		PruneChildren: true,
+	})
+
+	if err != nil {
+		imageInfo.Action = ActionKeep
+		return err
+	}
+
+	return nil
+}
+
+// parseImageTag parses a full image name (with tag) into repository and tag parts
+func parseImageTag(imageWithTag string) (repo string, tag string, ok bool) {
+	if !strings.Contains(imageWithTag, ":") {
+		return "", "", false
+	}
+
+	parts := strings.Split(imageWithTag, ":")
+	return parts[0], parts[1], true
+}

--- a/packages/api-server/internal/box/service/interface.go
+++ b/packages/api-server/internal/box/service/interface.go
@@ -13,18 +13,16 @@ import (
 // BoxService defines the interface for box operations
 type BoxService interface {
 	// Box lifecycle operations
-	Create(ctx context.Context, params *model.BoxCreateParams) (*model.Box, error)
+	List(ctx context.Context, params *model.BoxListParams) (*model.BoxListResult, error)
+	Get(ctx context.Context, id string) (*model.Box, error)
+	Create(ctx context.Context, params *model.BoxCreateParams, progressWriter io.Writer) (*model.Box, error)
 	Delete(ctx context.Context, id string, params *model.BoxDeleteParams) (*model.BoxDeleteResult, error)
-	Start(ctx context.Context, id string) (*model.BoxStartResult, error)
-	Stop(ctx context.Context, id string) (*model.BoxStopResult, error)
 	DeleteAll(ctx context.Context, params *model.BoxesDeleteParams) (*model.BoxesDeleteResult, error)
 	Reclaim(ctx context.Context) (*model.BoxReclaimResult, error)
 
-	// Box query operations
-	Get(ctx context.Context, id string) (*model.Box, error)
-	List(ctx context.Context, params *model.BoxListParams) (*model.BoxListResult, error)
-
-	// Box run command operations
+	// Box runtime operations
+	Start(ctx context.Context, id string) (*model.BoxStartResult, error)
+	Stop(ctx context.Context, id string) (*model.BoxStopResult, error)
 	Exec(ctx context.Context, id string, params *model.BoxExecParams) (*model.BoxExecResult, error)
 	ExecWS(ctx context.Context, id string, params *model.BoxExecWSParams, wsConn *websocket.Conn) (*model.BoxExecResult, error)
 	Run(ctx context.Context, id string, params *model.BoxRunParams) (*model.BoxRunResult, error)
@@ -32,10 +30,22 @@ type BoxService interface {
 	// Box file operations
 	GetArchive(ctx context.Context, id string, params *model.BoxArchiveGetParams) (*model.BoxArchiveResult, io.ReadCloser, error)
 	HeadArchive(ctx context.Context, id string, params *model.BoxArchiveHeadParams) (*model.BoxArchiveHeadResult, error)
-	ExtractArchive(ctx context.Context, id string, req *model.BoxArchiveExtractParams) error
+	ExtractArchive(ctx context.Context, id string, params *model.BoxArchiveExtractParams) error
+
+	// Box image operations
+	UpdateBoxImage(ctx context.Context, params *model.ImageUpdateParams) (*model.ImageUpdateResponse, error)
+	UpdateBoxImageWithProgress(ctx context.Context, params *model.ImageUpdateParams, progressWriter io.Writer) (*model.ImageUpdateResponse, error)
 
 	// GetExternalPort retrieves the host port mapping for a specific internal port of a box.
 	GetExternalPort(ctx context.Context, id string, internalPort int) (int, error)
+
+	// Added image management interfaces
+	// CheckImageExists checks if an image exists locally
+	CheckImageExists(ctx context.Context, params *model.BoxCreateParams) (bool, string)
+	// EnsureImagePulling ensures an image is being pulled, if not already in progress it will start pulling
+	EnsureImagePulling(ctx context.Context, imageName string)
+	// WaitForImagePull waits for an image pull to complete
+	WaitForImagePull(imageName string) <-chan struct{}
 }
 
 // Factory creates a new box service instance, accepting an AccessTracker

--- a/packages/api-server/pkg/box/image.go
+++ b/packages/api-server/pkg/box/image.go
@@ -1,0 +1,35 @@
+package model
+
+// ImageUpdateParams represents parameters for updating docker images
+type ImageUpdateParams struct {
+	ImageReference string `json:"imageReference,omitempty"` // Image reference to update (format: repo/image or repo/image:tag)
+	DryRun         bool   `json:"dryRun,omitempty"`         // If true, only report operations without executing them
+	Force          bool   `json:"force,omitempty"`          // If true, force remove images
+}
+
+// ImageUpdateResponse represents the response for the image update operation.
+type ImageUpdateResponse struct {
+	Images       []ImageInfo `json:"images"`                 // List of relevant images
+	ErrorMessage string      `json:"errorMessage,omitempty"` // General error message for the update process if needed.
+}
+
+// ImageStatus represents the status of an image
+type ImageStatus string
+
+const (
+	// ImageStatusUpToDate means this image is current and exists locally
+	ImageStatusUpToDate ImageStatus = "uptodate"
+	// ImageStatusOutdated means this image is outdated and exists locally
+	ImageStatusOutdated ImageStatus = "outdated"
+	// ImageStatusMissing means this image is current but does not exist locally
+	ImageStatusMissing ImageStatus = "missing"
+)
+
+// ImageInfo represents information about an image in the update context
+type ImageInfo struct {
+	ImageID    string      `json:"imageId,omitempty"` // Image ID (if exists locally)
+	Repository string      `json:"repository"`        // Image repository (e.g., "babelcloud/gbox-playwright")
+	Tag        string      `json:"tag"`               // Image tag (e.g., "b281f1a")
+	Status     ImageStatus `json:"status"`            // "uptodate", "outdated", or "missing"
+	Action     string      `json:"action,omitempty"`  // What will be done: "keep", "delete", "pull"
+}

--- a/packages/cli/cmd/box.go
+++ b/packages/cli/cmd/box.go
@@ -28,6 +28,7 @@ func NewBoxCommand() *cobra.Command {
 		NewBoxStopCommand(),
 		NewBoxReclaimCommand(),
 		NewBoxCpCommand(),
+		NewBoxImageCommand(),
 	)
 
 	return boxCmd

--- a/packages/cli/cmd/box_create.go
+++ b/packages/cli/cmd/box_create.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
+	"time"
 
-	"github.com/babelcloud/gbox/packages/api-server/pkg/box"
+	model "github.com/babelcloud/gbox/packages/api-server/pkg/box"
 	"github.com/babelcloud/gbox/packages/cli/config"
 	"github.com/spf13/cobra"
 )
@@ -176,12 +178,29 @@ func runCreate(opts *BoxCreateOptions, args []string) error {
 	apiBase := config.GetAPIURL()
 	apiURL := fmt.Sprintf("%s/api/v1/boxes", strings.TrimSuffix(apiBase, "/"))
 
-	resp, err := http.Post(apiURL, "application/json", bytes.NewBuffer(requestBody))
+	// Create a new HTTP request
+	httpRequest, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return fmt.Errorf("unable to create request: %v", err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("Accept", "application/json-stream") // Explicitly request streaming response
+
+	// Send the request using the default client
+	client := &http.Client{}
+	resp, err := client.Do(httpRequest)
 	if err != nil {
 		return fmt.Errorf("unable to connect to API server: %v", err)
 	}
 	defer resp.Body.Close()
 
+	// Check if response is a streaming response
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "application/json-stream" {
+		return handleBoxCreateStreamingResponse(resp.Body, opts.OutputFormat)
+	}
+
+	// Handle standard (non-streaming) response for backward compatibility
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read response: %v", err)
@@ -205,4 +224,258 @@ func runCreate(opts *BoxCreateOptions, args []string) error {
 		fmt.Printf("Box created with ID \"%s\"\n", response.ID)
 	}
 	return nil
+}
+
+// handleBoxCreateStreamingResponse processes a streaming response with progress updates for box creation
+func handleBoxCreateStreamingResponse(body io.Reader, outputFormat string) error {
+	fmt.Println("Creating box...")
+
+	// Store the layers being downloaded and their progress
+	layers := make(map[string]struct {
+		ID       string
+		Status   string
+		Progress string
+		Complete bool
+	})
+
+	var lastOutput time.Time
+	var totalLayers int
+	var completedLayers int
+	var finalResponse []byte
+
+	// Buffer to store the complete response for final parsing
+	responseBuffer := new(bytes.Buffer)
+	teeReader := io.TeeReader(body, responseBuffer)
+
+	decoder := json.NewDecoder(teeReader)
+	var box *model.Box
+
+	for {
+		var rawMessage json.RawMessage
+		if err := decoder.Decode(&rawMessage); err != nil {
+			if err == io.EOF {
+				// At EOF, the responseBuffer contains the full response
+				finalResponse = responseBuffer.Bytes()
+				break
+			}
+			return fmt.Errorf("error reading response stream: %v", err)
+		}
+
+		// Try to parse as a Docker pull progress message
+		var pullProgress struct {
+			ID             string          `json:"id"`
+			Status         string          `json:"status"`
+			Progress       string          `json:"progress"`
+			ProgressDetail json.RawMessage `json:"progressDetail"`
+			Error          string          `json:"error"`
+		}
+
+		if err := json.Unmarshal(rawMessage, &pullProgress); err == nil {
+			if pullProgress.Error != "" {
+				return fmt.Errorf("error from server: %s", pullProgress.Error)
+			}
+
+			// Update progress for this layer
+			if pullProgress.ID != "" {
+				// Update or add this layer
+				layer := layers[pullProgress.ID]
+				layer.ID = pullProgress.ID
+				layer.Status = pullProgress.Status
+
+				if pullProgress.Progress != "" {
+					layer.Progress = pullProgress.Progress
+				}
+
+				// Check if layer is complete
+				isNowCompleteEvent := (pullProgress.Status == "Download complete" || pullProgress.Status == "Pull complete")
+
+				if isNowCompleteEvent {
+					if !layer.Complete { // If it was not already marked as complete
+						layer.Complete = true // Mark it as complete now
+						completedLayers++     // Increment the count of completed layers
+					} else {
+						layer.Complete = true
+					}
+				}
+
+				layers[pullProgress.ID] = layer
+
+				// Update total count whenever we discover new layers
+				if len(layers) > totalLayers {
+					totalLayers = len(layers)
+				}
+			}
+
+			// Update the display (but rate limit to avoid flicker)
+			if time.Since(lastOutput) > 100*time.Millisecond || pullProgress.ID == "" {
+				lastOutput = time.Now()
+
+				// Only redraw if there's any layer information
+				if len(layers) > 0 {
+					displayImagePullProgress(layers, completedLayers, totalLayers)
+				} else if pullProgress.Status != "" {
+					fmt.Printf("\r\033[K%s", pullProgress.Status)
+					if pullProgress.Progress != "" {
+						fmt.Printf(" %s", pullProgress.Progress)
+					}
+				}
+			}
+
+			continue
+		}
+
+		// Try to parse as a custom status message
+		var statusMessage struct {
+			Status  string     `json:"status"`
+			Message string     `json:"message"`
+			Error   string     `json:"error"`
+			Box     *model.Box `json:"box"`
+		}
+
+		if err := json.Unmarshal(rawMessage, &statusMessage); err == nil {
+			if statusMessage.Error != "" {
+				return fmt.Errorf("error from server: %s", statusMessage.Error)
+			}
+
+			if statusMessage.Status == "complete" && statusMessage.Box != nil {
+				// Found the box info in the stream
+				box = statusMessage.Box
+				fmt.Printf("\r\033[KBox created successfully\n")
+			} else if statusMessage.Status == "prepare" {
+				fmt.Printf("\r\033[KPreparing: %s", statusMessage.Message)
+			} else if statusMessage.Message != "" {
+				fmt.Printf("\r\033[K%s: %s", statusMessage.Status, statusMessage.Message)
+			}
+		}
+	}
+
+	// Ensure we have a blank line after all the progress output
+	fmt.Print("\n")
+
+	// If box is still nil, try to parse the final response for box information
+	if box == nil && len(finalResponse) > 0 {
+		// Try to parse final response as a standard response first
+		var createResponse BoxCreateResponse
+		if err := json.Unmarshal(finalResponse, &createResponse); err == nil && createResponse.ID != "" {
+			// Simple ID-only response
+			if outputFormat == "json" {
+				fmt.Println(string(finalResponse))
+			} else {
+				fmt.Printf("Box created with ID \"%s\"\n", createResponse.ID)
+			}
+			return nil
+		}
+
+		// Try parsing as complete box object
+		var boxResponse struct {
+			Box *model.Box `json:"box"`
+		}
+		if err := json.Unmarshal(finalResponse, &boxResponse); err == nil && boxResponse.Box != nil {
+			box = boxResponse.Box
+		} else {
+			// Try parsing directly as a Box
+			var directBox model.Box
+			if err := json.Unmarshal(finalResponse, &directBox); err == nil && directBox.ID != "" {
+				box = &directBox
+			}
+		}
+	}
+
+	// Output the final result
+	if box != nil {
+		if outputFormat == "json" {
+			boxJSON, _ := json.MarshalIndent(box, "", "  ")
+			fmt.Println(string(boxJSON))
+		} else {
+			fmt.Printf("Box created with ID \"%s\"\n", box.ID)
+		}
+	} else {
+		fmt.Println("Box created successfully, but no details received")
+	}
+
+	return nil
+}
+
+// displayImagePullProgress prints the current download progress for all layers
+func displayImagePullProgress(layers map[string]struct {
+	ID       string
+	Status   string
+	Progress string
+	Complete bool
+}, completed, total int) {
+	// Clear line and move to beginning
+	fmt.Print("\r\033[K")
+
+	// Show overall progress
+	if total > 0 {
+		percentage := (float64(completed) / float64(total)) * 100
+		fmt.Printf("Overall progress: [%d/%d] %.1f%%\n", completed, total, percentage)
+	}
+
+	// Limit how many layers we display to avoid cluttering the screen
+	const maxDisplayLayers = 5
+
+	// Convert map to slice for better display control
+	layerSlice := make([]struct {
+		ID       string
+		Status   string
+		Progress string
+		Complete bool
+	}, 0, len(layers))
+
+	for _, layer := range layers {
+		layerSlice = append(layerSlice, layer)
+	}
+
+	// Prioritize incomplete layers
+	sort.Slice(layerSlice, func(i, j int) bool {
+		if layerSlice[i].Complete != layerSlice[j].Complete {
+			return !layerSlice[i].Complete // Incomplete layers first
+		}
+		return layerSlice[i].ID < layerSlice[j].ID // Then sort by ID
+	})
+
+	// Display up to maxDisplayLayers layers
+	displayCount := len(layerSlice)
+	if displayCount > maxDisplayLayers {
+		displayCount = maxDisplayLayers
+	}
+
+	for i := 0; i < displayCount; i++ {
+		layer := layerSlice[i]
+		if layer.Complete {
+			fmt.Printf("\r\033[K[✓] %s: %s\n",
+				shortenImageLayerID(layer.ID),
+				layer.Status)
+		} else {
+			fmt.Printf("\r\033[K[↓] %s: %s %s\n",
+				shortenImageLayerID(layer.ID),
+				layer.Status,
+				layer.Progress)
+		}
+	}
+
+	// If we're not showing all layers, indicate how many more there are
+	if len(layerSlice) > maxDisplayLayers {
+		remaining := len(layerSlice) - maxDisplayLayers
+		fmt.Printf("\r\033[K... and %d more layers ...\n", remaining)
+	}
+
+	// Move cursor back up to overwrite on next update
+	moveCursorUp := displayCount + 1 // +1 for the overall progress line
+	if len(layerSlice) > maxDisplayLayers {
+		moveCursorUp++ // +1 for the "and X more" line
+	}
+
+	for i := 0; i < moveCursorUp; i++ {
+		fmt.Print("\033[1A")
+	}
+}
+
+// shortenImageLayerID shortens a layer ID for display
+func shortenImageLayerID(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:12]
 }

--- a/packages/cli/cmd/box_image.go
+++ b/packages/cli/cmd/box_image.go
@@ -1,0 +1,446 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	model "github.com/babelcloud/gbox/packages/api-server/pkg/box"
+	"github.com/babelcloud/gbox/packages/cli/config"
+	"github.com/spf13/cobra"
+)
+
+// BoxImageUpdateOptions holds flags for the image update command
+type BoxImageUpdateOptions struct {
+	ImageReference string
+	DryRun         bool
+	OutputFormat   string
+	Force          bool
+}
+
+// NewBoxImageCommand returns the parent command for all box image operations
+func NewBoxImageCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "image",
+		Short: "Manage box container images",
+		Long:  `Operations related to Docker images used by boxes, such as updating, listing, or pruning images.`,
+	}
+
+	cmd.AddCommand(NewBoxImageUpdateCommand())
+	return cmd
+}
+
+// NewBoxImageUpdateCommand returns the command for updating box container images
+func NewBoxImageUpdateCommand() *cobra.Command {
+	opts := &BoxImageUpdateOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "update [flags]",
+		Short: "Update box container images",
+		Long: `Update Docker images used by boxes.
+
+This command will check if the specified image (or default box image if none provided) 
+is up-to-date locally, pulls the new version if needed, and removes outdated versions 
+to free up disk space. 
+
+Use the --dry-run flag to see which operations would be performed without actually 
+executing them.
+Use the --force flag to forcefully remove old images, even if they are used by stopped containers.`,
+		Example: `  # Update the default box image
+  gbox box image update
+
+  # Update a specific image
+  gbox box image update --name node:18
+
+  # Preview operations without executing them
+  gbox box image update --dry-run
+
+  # Force update and removal of old images
+  gbox box image update --force
+
+  # Update a specific image in dry run mode with JSON output
+  gbox box image update --name python:3.10 --dry-run --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runImageUpdate(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.ImageReference, "image", "", "Image name to update (default: babelcloud/gbox-playwright)")
+	flags.BoolVar(&opts.DryRun, "dry-run", false, "Only print what would be done, without executing operations")
+	flags.StringVar(&opts.OutputFormat, "output", "text", "Output format (json or text)")
+	flags.BoolVar(&opts.Force, "force", false, "Force removal of old images")
+
+	cmd.RegisterFlagCompletionFunc("output", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"json", "text"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	return cmd
+}
+
+// runImageUpdate executes the image update operation
+func runImageUpdate(opts *BoxImageUpdateOptions) error {
+	// Build API URL with query parameters
+	apiBase := config.GetAPIURL()
+	apiURL := fmt.Sprintf("%s/api/v1/boxes/images/update", strings.TrimSuffix(apiBase, "/"))
+
+	// Add query parameters if provided
+	queryParams := url.Values{}
+	if opts.ImageReference != "" {
+		queryParams.Add("image", opts.ImageReference)
+	}
+	if opts.DryRun {
+		queryParams.Add("dryRun", "true")
+	}
+	if opts.Force {
+		queryParams.Add("force", "true")
+	}
+
+	// Always request stream response
+	queryParams.Add("stream", "true")
+
+	// Append query parameters to URL if any
+	if len(queryParams) > 0 {
+		apiURL = fmt.Sprintf("%s?%s", apiURL, queryParams.Encode())
+	}
+
+	// Create request
+	req, err := http.NewRequest("POST", apiURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %v", err)
+	}
+
+	// Set Accept header to request json-stream response
+	req.Header.Set("Accept", "application/json-stream")
+	req.Header.Set("Content-Type", "application/json")
+
+	// Make the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("unable to connect to API server: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		responseBody, _ := io.ReadAll(resp.Body)
+		errMsg := fmt.Sprintf("API server returned HTTP %d", resp.StatusCode)
+		if len(responseBody) > 0 {
+			errMsg += fmt.Sprintf("\nResponse: %s", string(responseBody))
+		}
+		return fmt.Errorf("%s", errMsg)
+	}
+
+	// Process response using streaming handler
+	return handleStreamingResponse(resp.Body, opts)
+}
+
+// handleStreamingResponse processes a streaming response with progress updates
+func handleStreamingResponse(body io.Reader, opts *BoxImageUpdateOptions) error {
+	// Store the layers being downloaded and their progress
+	layers := make(map[string]struct {
+		ID       string
+		Status   string
+		Progress string
+		Complete bool
+	})
+
+	var lastOutput time.Time
+	var totalLayers int
+	var completedLayers int
+	decoder := json.NewDecoder(body)
+	var finalResponse *model.ImageUpdateResponse
+
+	for {
+		var rawMessage json.RawMessage
+		if err := decoder.Decode(&rawMessage); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("error reading response stream: %v", err)
+		}
+
+		// Try to parse as a Docker pull progress message
+		var pullProgress struct {
+			ID             string          `json:"id"`
+			Status         string          `json:"status"`
+			Progress       string          `json:"progress"`
+			ProgressDetail json.RawMessage `json:"progressDetail"`
+			Error          string          `json:"error"`
+		}
+
+		if err := json.Unmarshal(rawMessage, &pullProgress); err == nil {
+			if pullProgress.Error != "" {
+				return fmt.Errorf("error from server: %s", pullProgress.Error)
+			}
+
+			// Update progress for this layer
+			if pullProgress.ID != "" {
+				// Update or add this layer
+				layer := layers[pullProgress.ID]
+				layer.ID = pullProgress.ID
+				layer.Status = pullProgress.Status
+
+				if pullProgress.Progress != "" {
+					layer.Progress = pullProgress.Progress
+				}
+
+				// Check if layer is complete
+				if pullProgress.Status == "Download complete" || pullProgress.Status == "Pull complete" {
+					layer.Complete = true
+					completedLayers++
+				}
+
+				layers[pullProgress.ID] = layer
+
+				// Update total count for first time
+				if totalLayers == 0 && len(layers) > 0 {
+					totalLayers = len(layers)
+				}
+			}
+
+			// Update the display (but rate limit to avoid flicker)
+			if time.Since(lastOutput) > 100*time.Millisecond || pullProgress.ID == "" {
+				lastOutput = time.Now()
+
+				// Only redraw if there's any layer information
+				if len(layers) > 0 {
+					printProgress(layers, completedLayers, totalLayers)
+				} else if pullProgress.ID == "" && pullProgress.Status != "" &&
+					!(strings.EqualFold(pullProgress.Status, "prepare") ||
+						strings.EqualFold(pullProgress.Status, "preparing") ||
+						strings.EqualFold(pullProgress.Status, "waiting")) {
+					// Only print general status if it's not a layer update and not one of the ignored preliminary statuses.
+					fmt.Printf("\r%s", pullProgress.Status)
+					if pullProgress.Progress != "" {
+						fmt.Printf(" %s", pullProgress.Progress)
+					}
+					fmt.Println()
+				}
+			}
+
+			continue
+		}
+
+		// Try to parse as a final response
+		var response model.ImageUpdateResponse
+		if err := json.Unmarshal(rawMessage, &response); err == nil {
+			// Store the final response to display after the stream closes
+			finalResponse = &response
+			continue
+		}
+
+		// Try to parse as a custom status message
+		var statusMessage struct {
+			Status  string `json:"status"`
+			Message string `json:"message"`
+			Error   string `json:"error"`
+		}
+
+		if err := json.Unmarshal(rawMessage, &statusMessage); err == nil {
+			if statusMessage.Error != "" {
+				return fmt.Errorf("error from server: %s", statusMessage.Error)
+			}
+
+			if statusMessage.Status == "complete" {
+				fmt.Printf("\rCompleted: %s\n", statusMessage.Message)
+			} else if statusMessage.Status == "prepare" {
+				// Do nothing for "prepare" status to avoid confusing output
+			} else {
+				fmt.Printf("\r%s: %s\n", statusMessage.Status, statusMessage.Message)
+			}
+		}
+	}
+
+	// Ensure we have a blank line after all the progress output
+	fmt.Print("\n")
+
+	// If we got a final response, display it
+	if finalResponse != nil {
+		outputResults(finalResponse, opts.OutputFormat)
+	} else {
+		// If we didn't get a final response in the stream, fetch the results separately
+		finalResults, err := fetchFinalResults(opts)
+		if err != nil {
+			fmt.Printf("Warning: Could not fetch final results: %v\n", err)
+		} else if finalResults != nil {
+			outputResults(finalResults, opts.OutputFormat)
+		}
+	}
+
+	return nil
+}
+
+// fetchFinalResults makes a separate API call to get the current image status
+func fetchFinalResults(opts *BoxImageUpdateOptions) (*model.ImageUpdateResponse, error) {
+	// Build API URL with query parameters but without streaming
+	apiBase := config.GetAPIURL()
+	apiURL := fmt.Sprintf("%s/api/v1/boxes/images/update", strings.TrimSuffix(apiBase, "/"))
+
+	// Add query parameters if provided
+	queryParams := url.Values{}
+	if opts.ImageReference != "" {
+		queryParams.Add("image", opts.ImageReference)
+	}
+	queryParams.Add("dryRun", "true") // Use dry run to just get status without changes
+
+	// Append query parameters to URL
+	apiURL = fmt.Sprintf("%s?%s", apiURL, queryParams.Encode())
+
+	// Make the request
+	resp, err := http.Post(apiURL, "application/json", nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to API server: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("API server returned HTTP %d", resp.StatusCode)
+	}
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %v", err)
+	}
+
+	// Parse the response
+	var response model.ImageUpdateResponse
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %v", err)
+	}
+
+	return &response, nil
+}
+
+// printProgress prints the current download progress for all layers
+func printProgress(layers map[string]struct {
+	ID       string
+	Status   string
+	Progress string
+	Complete bool
+}, completed, total int) {
+	// Clear line and move to beginning
+	fmt.Print("\r\033[K")
+
+	// Show overall progress
+	if total > 0 {
+		percentage := (float64(completed) / float64(total)) * 100
+		fmt.Printf("Overall progress: [%d/%d] %.1f%%\n", completed, total, percentage)
+	}
+
+	// Limit how many layers we display to avoid cluttering the screen
+	const maxDisplayLayers = 5
+
+	// Convert map to slice for better display control
+	layerSlice := make([]struct {
+		ID       string
+		Status   string
+		Progress string
+		Complete bool
+	}, 0, len(layers))
+
+	for _, layer := range layers {
+		layerSlice = append(layerSlice, layer)
+	}
+
+	// Prioritize incomplete layers
+	sort.Slice(layerSlice, func(i, j int) bool {
+		if layerSlice[i].Complete != layerSlice[j].Complete {
+			return !layerSlice[i].Complete // Incomplete layers first
+		}
+		return layerSlice[i].ID < layerSlice[j].ID // Then sort by ID
+	})
+
+	// Display up to maxDisplayLayers layers
+	displayCount := len(layerSlice)
+	if displayCount > maxDisplayLayers {
+		displayCount = maxDisplayLayers
+	}
+
+	for i := 0; i < displayCount; i++ {
+		layer := layerSlice[i]
+		if layer.Complete {
+			fmt.Printf("\r\033[K[✓] %s: %s\n",
+				shortenLayerID(layer.ID),
+				layer.Status)
+		} else {
+			fmt.Printf("\r\033[K[↓] %s: %s %s\n",
+				shortenLayerID(layer.ID),
+				layer.Status,
+				layer.Progress)
+		}
+	}
+
+	// If we're not showing all layers, indicate how many more there are
+	if len(layerSlice) > maxDisplayLayers {
+		remaining := len(layerSlice) - maxDisplayLayers
+		fmt.Printf("\r\033[K... and %d more layers ...\n", remaining)
+	}
+
+	// Move cursor back up to overwrite on next update
+	moveCursorUp := displayCount + 1 // +1 for the overall progress line
+	if len(layerSlice) > maxDisplayLayers {
+		moveCursorUp++ // +1 for the "and X more" line
+	}
+
+	for i := 0; i < moveCursorUp; i++ {
+		fmt.Print("\033[1A")
+	}
+}
+
+// shortenLayerID shortens a layer ID for display
+func shortenLayerID(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:12]
+}
+
+// outputResults displays the results of the image update operation
+func outputResults(response *model.ImageUpdateResponse, outputFormat string) {
+	if outputFormat == "json" {
+		// Pretty print JSON
+		jsonData, _ := json.MarshalIndent(response, "", "  ")
+		fmt.Println(string(jsonData))
+	} else {
+		// Text format
+		if response.ErrorMessage != "" {
+			fmt.Printf("Error: %s\n\n", response.ErrorMessage)
+		}
+
+		if len(response.Images) == 0 {
+			if response.ErrorMessage == "" {
+				fmt.Println("No images found or processed.")
+			}
+			return
+		}
+
+		// Print table header
+		fmt.Printf("%-50s | %-15s | %-10s\n", "Image", "Status", "Action")
+		fmt.Printf("%-50s-+-%-15s-+-%-10s\n", strings.Repeat("-", 50), strings.Repeat("-", 15), strings.Repeat("-", 10))
+
+		// Print table rows
+		for _, img := range response.Images {
+			imageName := fmt.Sprintf("%s:%s", img.Repository, img.Tag)
+			var status string
+
+			switch img.Status {
+			case model.ImageStatusUpToDate:
+				status = "Up-to-date"
+			case model.ImageStatusMissing:
+				status = "Missing"
+			case model.ImageStatusOutdated:
+				status = "Outdated"
+			default:
+				status = string(img.Status)
+			}
+
+			fmt.Printf("%-50s | %-15s | %-10s\n", imageName, status, img.Action)
+		}
+	}
+}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -25,7 +25,7 @@
   "author": "BabelCloud",
   "license": "Apache-2.0",
   "dependencies": {
-    "@gru.ai/gbox": "0.0.3",
+    "@gru.ai/gbox": "0.0.4",
     "@modelcontextprotocol/sdk": "^1.7.0",
     "axios": "^1.8.4",
     "dotenv-defaults": "^5.0.2",

--- a/packages/mcp-server/pnpm-lock.yaml
+++ b/packages/mcp-server/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@gru.ai/gbox':
-        specifier: 0.0.3
-        version: 0.0.3(ws@8.18.2)
+        specifier: 0.0.4
+        version: 0.0.4(ws@8.18.2)
       '@modelcontextprotocol/sdk':
         specifier: ^1.7.0
         version: 1.7.0
@@ -380,8 +380,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@gru.ai/gbox@0.0.3':
-    resolution: {integrity: sha512-KTBUXU6Nmevg0aSjI4He2MUUK6bRanUKVI4yvWm+CO1/UtOrWZ8U/2nQpw/MHTz9JOCIKI/ULLaMmQyrj6YDrA==}
+  '@gru.ai/gbox@0.0.4':
+    resolution: {integrity: sha512-7L9l1donaB2nlp3yiZMlKgt5X1L2AiwqBtohG4uyOimHnRkDrbhaVT2p9GLevsiNH7g/Hgjy3IUOelLKADdJWg==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1808,7 +1808,7 @@ snapshots:
   '@esbuild/win32-x64@0.25.1':
     optional: true
 
-  '@gru.ai/gbox@0.0.3(ws@8.18.2)':
+  '@gru.ai/gbox@0.0.4(ws@8.18.2)':
     dependencies:
       '@types/tar': 6.1.13
       isomorphic-ws: 5.0.0(ws@8.18.2)

--- a/packages/mcp-server/responseData.json
+++ b/packages/mcp-server/responseData.json
@@ -1,0 +1,4 @@
+{
+  "code": "ImagePullInProgress",
+  "message": "Image babelcloud/gbox-playwright:7614d46 is being pulled, but not yet completed. Please try again later"
+}

--- a/packages/mcp-server/src/service/gbox.instance.ts
+++ b/packages/mcp-server/src/service/gbox.instance.ts
@@ -15,7 +15,7 @@ import {
     FileManager,
     GBoxFile,
     type ImagePullStatus,
-} from "../../../sdk/typescript/src/index";
+} from "@gru.ai/gbox";
 
 const GBOX_URL = process.env.GBOX_URL || 'http://localhost:28080';
 

--- a/packages/mcp-server/src/service/gbox.instance.ts
+++ b/packages/mcp-server/src/service/gbox.instance.ts
@@ -14,7 +14,8 @@ import {
     BoxBrowserManager,
     FileManager,
     GBoxFile,
-} from "@gru.ai/gbox";
+    type ImagePullStatus,
+} from "../../../sdk/typescript/src/index";
 
 const GBOX_URL = process.env.GBOX_URL || 'http://localhost:28080';
 
@@ -41,5 +42,6 @@ export {
     type VisionScreenshotResult,
     type VisionScreenshotParams,
     type FileShareApiResponse,
+    type ImagePullStatus,
 };
 

--- a/packages/mcp-server/src/tools/run-python.ts
+++ b/packages/mcp-server/src/tools/run-python.ts
@@ -38,16 +38,48 @@ export const handleRunPython = withLogging(
     );
 
     // Get or create box
-    const id = await gbox.boxes.getOrCreateBox({
+    const result = await gbox.boxes.getOrCreateBox({
       boxId,
       image: config.images.playwright,
       sessionId,
       signal,
     });
 
+    // Check if image is being pulled
+    if (result.imagePullStatus?.inProgress) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              status: "image_pulling",
+              message: result.imagePullStatus.message,
+              imageName: result.imagePullStatus.imageName
+            }, null, 2),
+          },
+        ],
+      };
+    }
+
+    // Ensure we have a valid boxId
+    if (!result.boxId) {
+      logger.error("Failed to get or create box");
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              status: "error",
+              message: "Failed to get or create box"
+            }, null, 2),
+          },
+        ],
+      };
+    }
+
     // Run command
-    const result = await gbox.boxes.runInBox(
-      id,
+    const runResult = await gbox.boxes.runInBox(
+      result.boxId,
       ["python3"],
       code,
       100, // stdoutLineLimit
@@ -56,14 +88,14 @@ export const handleRunPython = withLogging(
     );
 
     logger.info("Python code executed successfully");
-    if (!result.stderr && !result.stdout) {
-      result.stdout = "[No output]";
+    if (!runResult.stderr && !runResult.stdout) {
+      runResult.stdout = "[No output]";
     }
     return {
       content: [
         {
           type: "text" as const,
-          text: JSON.stringify(result, null, 2),
+          text: JSON.stringify(runResult, null, 2),
         },
       ],
     };

--- a/packages/sdk/typescript/package.json
+++ b/packages/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gru.ai/gbox",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Node.js SDK for Gru gbox. Gbox provides a self-hostable sandbox environment designed for AI agents, offering capabilities like terminal access, file management, and browser interaction. \nThis SDK allows Node.js applications to programmatically manage GBox resources, primarily the execution environments (Boxes) and the shared file volume, enabling seamless integration with agent workflows.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/typescript/src/api/box.api.ts
+++ b/packages/sdk/typescript/src/api/box.api.ts
@@ -18,9 +18,19 @@ import type {
 } from '../types/box.ts';
 import { StreamTypeStdout, StreamTypeStderr } from '../types/box.ts';
 import { WebSocketClient } from './ws-client.ts';
-  import { logger } from '../logger.ts';
-
+import { logger } from '../logger.ts';
+import fs from 'fs';
 const API_PREFIX = '/api/v1/boxes';
+
+export class ImagePullInProgressError extends Error {
+  imageName: string;
+  
+  constructor(message: string, imageName: string) {
+    super(message);
+    this.name = 'ImagePullInProgressError';
+    this.imageName = imageName;
+  }
+}
 
 export class BoxApi extends Client {
   /**
@@ -75,6 +85,31 @@ export class BoxApi extends Client {
   /**
    * Create a new box.
    * POST /api/v1/boxes
+   * 
+   * @param options - Box creation options
+   * @param options.timeout - Duration string (e.g., '30s', '1m') for image pull timeout. 
+   *                          If specified and the image doesn't exist locally, the API will:
+   *                          1. Start an async image pull
+   *                          2. Return a response with imagePullStatus information instead of throwing
+   *                          3. The client should monitor or retry creation after waiting
+   * @param signal - Optional AbortSignal to cancel the request
+   * @returns The created box data, or a response with imagePullStatus if image is being pulled
+   * 
+   * @example
+   * ```typescript
+   * // Create a box with timeout
+   * const response = await client.boxes.create({
+   *   image: "my-image:latest",
+   *   timeout: "30s" // Wait up to 30 seconds for image pull
+   * });
+   * 
+   * if (response.imagePullStatus?.inProgress) {
+   *   console.log(`Image ${response.imagePullStatus.imageName} is being pulled: ${response.imagePullStatus.message}`);
+   *   // Implement retry logic or notify user to try again
+   * } else {
+   *   console.log("Box created successfully:", response.id);
+   * }
+   * ```
    */
   async create(
     options: BoxCreateOptions,
@@ -91,17 +126,34 @@ export class BoxApi extends Client {
     if (options.workingDir) {
       apiOptions.workingDir = options.workingDir;
     }
-    const response = await super.post<BoxCreateResponse>(
-      API_PREFIX,
-      apiOptions,
-      undefined,
-      undefined,
-      signal
-    );
+    
+    const timeoutParam = options.timeout;
+    if (timeoutParam) {
+      delete apiOptions.timeout; 
+    }
+    
+    const params: Record<string, string> = {};
+    if (timeoutParam) {
+      params.timeout = timeoutParam;
+    }
 
-    const mappedResponse = this.mapLabels(response);
+      const responseData = await super.post<BoxCreateResponse>(
+        API_PREFIX,
+        apiOptions,
+        params,
+        undefined, // headers
+        signal
+      );
 
-    return mappedResponse;
+      // Check if responseData indicates ImagePullInProgress
+      // This assumes that if the server responds with 202 and a specific body for ImagePullInProgress,
+      // super.post() will return that body as responseData without throwing an error for the 202 status.
+      if (responseData.code! === 'ImagePullInProgress') {
+        return responseData;
+      }
+
+      // Otherwise, it's treated as a regular successful box creation (e.g., 201 Created)
+      return this.mapLabels(responseData);
   }
 
   /**

--- a/packages/sdk/typescript/src/api/box.api.ts
+++ b/packages/sdk/typescript/src/api/box.api.ts
@@ -145,14 +145,9 @@ export class BoxApi extends Client {
         signal
       );
 
-      // Check if responseData indicates ImagePullInProgress
-      // This assumes that if the server responds with 202 and a specific body for ImagePullInProgress,
-      // super.post() will return that body as responseData without throwing an error for the 202 status.
       if (responseData.code! === 'ImagePullInProgress') {
         return responseData;
       }
-
-      // Otherwise, it's treated as a regular successful box creation (e.g., 201 Created)
       return this.mapLabels(responseData);
   }
 

--- a/packages/sdk/typescript/src/index.ts
+++ b/packages/sdk/typescript/src/index.ts
@@ -30,3 +30,9 @@ export * from './types/browser.ts';
 
 // Re-export SdkLogger and LogLevel for external use
 export { logger } from './logger.ts';
+
+// Export library components
+export * from './client.ts';
+
+// Export specific error classes (kept for backward compatibility)
+export { ImagePullInProgressError } from './api/box.api.ts';

--- a/packages/sdk/typescript/src/managers/box.manager.ts
+++ b/packages/sdk/typescript/src/managers/box.manager.ts
@@ -58,7 +58,7 @@ export class BoxManager {
     const response = await this.boxApi.create(options, signal);
     // Instantiate Box model directly using the response data, passing both APIs
     if (response.code === 'ImagePullInProgress') {
-      throw new Error(`${response.code}: ${response.message}`);
+      throw new Error(`Code: ${response.code}, Message: ${response.message}`);
     }
     return new Box(response, this.boxApi, this.browserApi);
   }

--- a/packages/sdk/typescript/src/managers/box.manager.ts
+++ b/packages/sdk/typescript/src/managers/box.manager.ts
@@ -57,6 +57,9 @@ export class BoxManager {
   async create(options: BoxCreateOptions, signal?: AbortSignal): Promise<Box> {
     const response = await this.boxApi.create(options, signal);
     // Instantiate Box model directly using the response data, passing both APIs
+    if (response.code === 'ImagePullInProgress') {
+      throw new Error(`${response.code}: ${response.message}`);
+    }
     return new Box(response, this.boxApi, this.browserApi);
   }
 

--- a/packages/sdk/typescript/src/types/box.ts
+++ b/packages/sdk/typescript/src/types/box.ts
@@ -1,5 +1,6 @@
 // No Node.js stream import needed for Web Streams
 
+
 // Basic structure for a Box object returned by the API
 export interface BoxData {
   id: string;
@@ -7,6 +8,13 @@ export interface BoxData {
   image: string;
   labels?: Record<string, string>;
   // Add other fields based on API responses (e.g., ports, created_at)
+}
+
+// Image pull status information
+export interface ImagePullStatus {
+  inProgress: boolean;
+  imageName: string;
+  message: string;
 }
 
 // Options for creating a new Box
@@ -19,6 +27,7 @@ export interface BoxCreateOptions {
   workingDir?: string;
   labels?: Record<string, string>; // Matches 'extra_labels' in Python API but mapped here
   volumes?: VolumeMount[];
+  timeout?: string; // Duration string for image pull timeout (e.g., '30s', '1m')
 }
 
 export interface VolumeMount {
@@ -43,7 +52,10 @@ export interface BoxListResponse {
 export type BoxGetResponse = BoxData; // Assuming API returns the box data directly
 
 // Response structure for creating a box
-export type BoxCreateResponse = BoxData & { message?: string };
+export type BoxCreateResponse = BoxData & { 
+  code?: string;
+  message?: string;
+};
 
 // Filters for listing boxes
 export interface BoxListFilters {


### PR DESCRIPTION
1. server support image update api (for deleting outdated image at local ws and new image downloading)
2. The server supports two creation modes: JSON request and JSON stream. The JSON stream mode continuously sends image pulling progress updates to the client. In JSON request mode, the client must specify a timeout parameter. If the operation exceeds the timeout, the server will respond with HTTP status 202 Accepted.
3. cli support new update cmd for call severside update api
4. cli support display image pulling process when using update or create cmd
5. ts sdk fit changes above
6. mcp fit changes above
MCP inspect:
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/0577d1d3-7524-4499-bae0-48d0326b54b6" />
