### PR TITLE
Add supervisor.sock to supervisor.conf; bump playwright version

### DIFF
--- a/images/playwright/Dockerfile
+++ b/images/playwright/Dockerfile
@@ -1,6 +1,6 @@
 ARG REGISTRY=babelcloud
 ARG TAG=latest # Define ARG for base image tag
-ARG PLAYWRIGHT_VERSION=1.51.1 # Define Playwright version ARG
+ARG PLAYWRIGHT_VERSION=1.52.0 # Define Playwright version ARG
 
 FROM ${REGISTRY}/gbox-python:${TAG}
 

--- a/images/python/supervisord.conf
+++ b/images/python/supervisord.conf
@@ -7,6 +7,15 @@ logfile=/var/log/supervisor/supervisord.log
 logfile_maxbytes=10MB
 logfile_backups=3
 
+[unix_http_server]
+file=/var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
 [include]
 files = /etc/supervisor/conf.d/*.conf # Include program configs from conf.d
 


### PR DESCRIPTION
Test log:
```shell
root@6ee9a98cbb9b:~# supervisorctl status
ffmpeg_stream                    RUNNING   pid 422, uptime 0:00:06
playwright                       RUNNING   pid 18, uptime 0:00:40
ttyd                             RUNNING   pid 19, uptime 0:00:40
vnc:novncproxy                   RUNNING   pid 16, uptime 0:00:40
vnc:x11vnc                       RUNNING   pid 15, uptime 0:00:40
vnc:xvfb                         RUNNING   pid 14, uptime 0:00:40
root@6ee9a98cbb9b:~# sueprvisorctl stop ffmpeg_stream
bash: sueprvisorctl: command not found
root@6ee9a98cbb9b:~# supervisorctl stop ffmpeg_stream
ffmpeg_stream: stopped
root@6ee9a98cbb9b:~# supervisorctl status
ffmpeg_stream                    STOPPED   May 27 06:54 AM
playwright                       RUNNING   pid 18, uptime 0:01:03
ttyd                             RUNNING   pid 19, uptime 0:01:03
vnc:novncproxy                   RUNNING   pid 16, uptime 0:01:03
vnc:x11vnc                       RUNNING   pid 15, uptime 0:01:03
vnc:xvfb                         RUNNING   pid 14, uptime 0:01:03
root@6ee9a98cbb9b:~# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   2212  1012 ?        Ss   06:53   0:00 /usr/bin/tini -- /entrypoint.sh sleep infinity
root           7  0.0  0.0   2224  1152 ?        S    06:53   0:00 sleep infinity
root          13  0.2  0.2  37204 28980 ?        S    06:53   0:00 /usr/bin/python3 /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
root          14  0.2  0.5 231384 73424 ?        S    06:53   0:00 Xvfb :1 -screen 0 1280x1024x24 -ac +extension GLX +render -noreset
root          15  0.5  0.1  99268 15396 ?        S    06:53   0:00 x11vnc -display :1 -forever -shared -passwdfile /root/.vnc/plaintext_passwd -ncache 10 -geometry 1280x1024
root          16  0.1  0.2  52092 35080 ?        S    06:53   0:00 /usr/bin/python3 /usr/bin/websockify --web /usr/share/novnc/ 6080 localhost:5900
root          18  0.7  0.6 1059404 79436 ?       Sl   06:53   0:00 npm exec playwright@1.52.0 run-server --port 3000 --host 0.0.0.0
root          19  0.0  0.1  17932 17220 ?        S    06:53   0:00 /usr/local/bin/ttyd -W -p 7681 bash
root          54  0.0  0.0   2324  1368 ?        S    06:53   0:00 sh -c playwright run-server --port 3000 --host 0.0.0.0
root          55  0.6  0.7 771980 86216 ?        Sl   06:53   0:00 node /root/.npm/_npx/c61c9351a0dbcfa7/node_modules/.bin/playwright run-server --port 3000 --host 0.0.0.0
root          95  0.0  0.0   4060  3220 pts/0    Ss   06:53   0:00 bash
root         460  0.0  0.0   8168  3876 pts/0    R+   06:54   0:00 ps aux
```
