### PR TITLE
⚡️ patch: fix commit info in brew install procedure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Write commit sha to file
+        run: git rev-parse HEAD > COMMIT
+
       - name: Extract version from tag
         shell: bash
         run: |


### PR DESCRIPTION
主要解决 install 过程由于在非 git 仓库中，不能计算版本号信息，需要把版本信息在构建压缩包的时候加入到其中。

借鉴了https://github.com/twpayne/chezmoi/ 处理 commit sha 的方式，具体如下：
```rb
  def install
    ldflags = %W[
      -s -w
      -X main.version=#{version}
      -X main.commit=#{File.read("COMMIT")} # when releaseing, file "COMMIT" will be created to use here 
      -X main.date=#{time.iso8601}
      -X main.builtBy=#{tap.user}
    ]
    system "go", "build", *std_go_args(ldflags:)
```
我们的 gbox.rb 类似：
```rb
  def install
    system "make", "install", "prefix=#{prefix}", "VERSION=#{version}", "COMMIT_ID=#{File.read("COMMIT")}", "BUILD_TIME=#{time.iso8601}"
    generate_completions_from_executable(bin/"gbox", "completion")
  end

```