### PR TITLE
🐛fix: provide source distribution include version info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,6 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Write commit sha to file
-        run: git rev-parse HEAD > COMMIT
-
       - name: Extract version from tag
         shell: bash
         run: |
@@ -64,8 +61,11 @@ jobs:
           pnpm install
           pnpm build
 
-      - name: Build and create distribution
+      - name: Build and create binary distributions
         run: make dist VERSION=${{ env.VERSION }}
+
+      - name: Build source distribution for Homebrew
+        run: make dist-source VERSION=${{ env.VERSION }}
 
       - name: Create Release
         id: create_release
@@ -74,6 +74,8 @@ jobs:
           files: |
             dist/gbox-*.tar.gz
             dist/gbox-*.tar.gz.sha256
+            dist/gbox-v*.tar.gz
+            dist/gbox-v*.tar.gz.sha256
           draft: true
           prerelease: false
           generate_release_notes: true

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,23 @@ dist: build ## Create all distribution packages
 	@echo "All distribution packages created:"
 	@ls -1 $(DIST_PACKAGES) 2>/dev/null || echo "No packages were created"
 
+.PHONY: dist-source
+dist-source: ## Create a source code distribution package
+	@echo "Creating source distribution..."
+	@git rev-parse HEAD > COMMIT
+	@rm -rf $(DIST_DIR)/gbox-$(VERSION)
+	@mkdir -p $(DIST_DIR)/gbox-$(VERSION)
+	@echo "Copying source files..."
+	@git archive HEAD | tar -x -C $(DIST_DIR)/gbox-$(VERSION)
+	@cp COMMIT $(DIST_DIR)/gbox-$(VERSION)/COMMIT
+	@echo "Creating source archive..."
+	@(cd $(DIST_DIR) && tar -czf gbox-v$(VERSION).tar.gz gbox-$(VERSION))
+	@rm -rf $(DIST_DIR)/gbox-$(VERSION)
+	@rm COMMIT
+	@(cd $(DIST_DIR) && sha256sum gbox-v$(VERSION).tar.gz > gbox-v$(VERSION).tar.gz.sha256)
+	@echo "Source distribution package created: $(DIST_DIR)/gbox-v$(VERSION).tar.gz"
+	@echo "SHA256 checksum created: $(DIST_DIR)/gbox-v$(VERSION).tar.gz.sha256"
+
 # Install for Homebrew
 .PHONY: install
 install: ## Install for Homebrew


### PR DESCRIPTION
发现 github 自动构建的源码包不会包含 CI 过程中产生的文件，所以在 release action 上手动通过 makefile 构建包含 COMMIT 信息的源码包给 homebrew install 使用