### PR TITLE
🐛fix: agent memory lost due to the base64 image

### DIFF
--- a/packages/cli/cmd/mcp_export.go
+++ b/packages/cli/cmd/mcp_export.go
@@ -215,7 +215,7 @@ func exportConfig(mergeTo string, dryRun bool, serverType string) error {
 
 		// Handle claude-code option by outputting claude mcp add command
 		if mergeTo == "claude-code" {
-			return outputClaudeCodeCommand(serverType, serverScriptAbs, mcpServerDir, dryRun)
+			return outputClaudeCodeCommand(serverType, serverScriptAbs, mcpServerDir)
 		}
 
 		targetConfig := claudeConfig
@@ -326,7 +326,7 @@ func mergeAndMarshalConfigs(targetPath string, newConfig McpConfig) ([]byte, err
 }
 
 // outputClaudeCodeCommand outputs the claude mcp add command for claude-code integration
-func outputClaudeCodeCommand(serverType, serverScriptAbs, mcpServerDir string, dryRun bool) error {
+func outputClaudeCodeCommand(serverType, serverScriptAbs, mcpServerDir string) error {
 	serverName := "gbox"
 	if serverType == "android" {
 		serverName = "gbox-android"

--- a/packages/mcp-android-server/src/tools/ai-action.ts
+++ b/packages/mcp-android-server/src/tools/ai-action.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { attachBox } from "../gboxsdk/index.js";
 import type { MCPLogger } from "../mcp-logger.js";
 import type { ActionAI } from "gbox-sdk";
+import { sanitizeResult } from "./utils.js";
 
 
 export const AI_ACTION_TOOL = "ai_action";
@@ -93,40 +94,6 @@ export function handleAiAction(logger: MCPLogger) {
 
       // Build content array with text and images
       const content: Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }> = [];
-
-      // Create a sanitized version of result with truncated base64 data
-      const sanitizeResult = (obj: any): any => {
-        if (typeof obj !== 'object' || obj === null) {
-          return obj;
-        }
-        
-        if (Array.isArray(obj)) {
-          return obj.map(sanitizeResult);
-        }
-        
-        const sanitized: any = {};
-        for (const [key, value] of Object.entries(obj)) {
-          if (key === 'uri' && typeof value === 'string') {
-            // Truncate base64 data URIs
-            if (value.startsWith('data:')) {
-              const match = value.match(/^(data:.+;base64,)(.*)$/);
-              if (match && match[2].length > 20) {
-                sanitized[key] = match[1] + match[2].substring(0, 20) + '...';
-              } else {
-                sanitized[key] = value;
-              }
-            } else if (value.length > 20) {
-              // Truncate other long strings that might be base64
-              sanitized[key] = value.substring(0, 20) + '...';
-            } else {
-              sanitized[key] = value;
-            }
-          } else {
-            sanitized[key] = sanitizeResult(value);
-          }
-        }
-        return sanitized;
-      };
 
       // Add text result with sanitized data
       content.push({

--- a/packages/mcp-android-server/src/tools/press-key.ts
+++ b/packages/mcp-android-server/src/tools/press-key.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { attachBox } from "../gboxsdk/index.js";
 import type { MCPLogger } from "../mcp-logger.js";
 import type { ActionPressKey } from "gbox-sdk";
+import { sanitizeResult } from "./utils.js";
 
 export const PRESS_KEY_TOOL = "press_key";
 
@@ -115,10 +116,10 @@ export function handlePressKey(logger: MCPLogger) {
       // Build content array with text and images
       const content: Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }> = [];
 
-      // Add text result
+      // Add text result with sanitized data
       content.push({
         type: "text" as const,
-        text: JSON.stringify(result, null, 2),
+        text: JSON.stringify(sanitizeResult(result), null, 2),
       });
 
       // Add all images

--- a/packages/mcp-android-server/src/tools/utils.ts
+++ b/packages/mcp-android-server/src/tools/utils.ts
@@ -1,0 +1,36 @@
+/**
+ * Sanitizes result objects by truncating base64 data URIs to improve readability
+ * while preserving the full data for actual image display
+ */
+export const sanitizeResult = (obj: any): any => {
+  if (typeof obj !== 'object' || obj === null) {
+    return obj;
+  }
+  
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeResult);
+  }
+  
+  const sanitized: any = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === 'uri' && typeof value === 'string') {
+      // Truncate base64 data URIs
+      if (value.startsWith('data:')) {
+        const match = value.match(/^(data:.+;base64,)(.*)$/);
+        if (match && match[2].length > 20) {
+          sanitized[key] = match[1] + match[2].substring(0, 20) + '...';
+        } else {
+          sanitized[key] = value;
+        }
+      } else if (value.length > 20) {
+        // Truncate other long strings that might be base64
+        sanitized[key] = value.substring(0, 20) + '...';
+      } else {
+        sanitized[key] = value;
+      }
+    } else {
+      sanitized[key] = sanitizeResult(value);
+    }
+  }
+  return sanitized;
+};


### PR DESCRIPTION
mcp tools 调用 的 base64 image 返回太长，导致 agent 失忆

<img width="704" alt="截屏2025-07-07 18 21 15" src="https://github.com/user-attachments/assets/a8171ef9-f609-4c51-addf-1a1348df4afd" />
