### PR TITLE
🐛 fix: Wrongly got tar.gz instead of zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - name: Checkout code
@@ -77,7 +80,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/gbox-*.tar.gz


### PR DESCRIPTION
尝试修复两个问题：
1. 一个是 CI release 的报错：Error: Failed to upload release asset gbox-v0.0.15.tar.gz.sha256. received status code 404 https://github.com/babelcloud/gbox/actions/runs/16497143703/job/46645549515 
（这个压缩包是存在的，但是报错说找不到，怀疑是 softprops/action-gh-release 版本需要用 @2
2. 另一个是 makefile 的问题，CI release 之后产生的是 gbox-windows-xxx-0.0.15.tar.gz 而不是 zip 压缩包。cursor 给出的思路是GitHub Actions /bin/sh 默认是指向 dash，一个轻量级的 shell，不认识[[ ... ]] 这个语法，导致条件不成立。@vangie