### PR TITLE
⬆️ perf: anbondon path config for mcp export, using npx cmd

### DIFF
--- a/packages/cli/cmd/mcp_export_test.go
+++ b/packages/cli/cmd/mcp_export_test.go
@@ -156,7 +156,7 @@ func TestNewMcpExportCommand(t *testing.T) {
 
 	// Verify command basic properties
 	assert.Equal(t, "export", cmd.Use)
-	assert.Equal(t, "Export MCP configuration for Claude Desktop/Cursor", cmd.Short)
+	assert.Equal(t, "Export MCP configuration for Claude Desktop/Cursor (Android only)", cmd.Short)
 
 	// Verify flag options
 	mergeTo, err := cmd.Flags().GetString("merge-to")
@@ -166,4 +166,6 @@ func TestNewMcpExportCommand(t *testing.T) {
 	dryRun, err := cmd.Flags().GetBool("dry-run")
 	require.NoError(t, err)
 	assert.Equal(t, false, dryRun)
+
+	// The 'type' flag is removed, so we do not test it
 }


### PR DESCRIPTION
<img width="628" height="191" alt="截屏2025-07-30 00 09 39" src="https://github.com/user-attachments/assets/10cced40-2a41-4d7c-9889-77c27631068c" />

直接就用 npx 的版本，不然 npm 版本由于没有打包 mcp 构建产物导致 mcp export 的时候报错路径找不到

<img width="1096" height="554" alt="img_v3_02ol_e0ea0a19-c8db-4c8b-b37d-f9825d084f3g" src="https://github.com/user-attachments/assets/ba1f1c42-db5c-4bef-bc79-a959b4b14034" />

