### PR TITLE
:star: feat: add device connection management commands

### DIFF
--- a/packages/cli/cmd/box.go
+++ b/packages/cli/cmd/box.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/babelcloud/gbox/packages/cli/internal/profile"
 	"github.com/spf13/cobra"
 )
 
@@ -19,7 +20,7 @@ func NewBoxCommand() *cobra.Command {
   gbox box exec 550e8400-e29b-41d4-a716-446655440000 -- ls             # Execute a command in a box
   gbox box cp ./local_file 550e8400-e29b-41d4-a716-446655440000:/work  # Copy a local file to a box`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			pm := NewProfileManager()
+			pm := profile.NewProfileManager()
 			if err := pm.Load(); err != nil {
 				// If we cannot load the profile, do not block execution – just inform the user.
 				fmt.Fprintf(os.Stderr, "Warning: failed to load profile file: %v\n", err)

--- a/packages/cli/cmd/box_exec.go
+++ b/packages/cli/cmd/box_exec.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/babelcloud/gbox/packages/cli/config"
+	"github.com/babelcloud/gbox/packages/cli/internal/profile"
 	"github.com/gorilla/websocket"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -270,7 +271,7 @@ func runExec(opts *BoxExecOptions) error {
 
 // runExecWebSocket 通过新的 WebSocket API 执行交互式命令
 func runExecWebSocket(opts *BoxExecOptions, resolvedBoxID string) error {
-	pm := NewProfileManager()
+	pm := profile.NewProfileManager()
 	if err := pm.Load(); err != nil {
 		// handle error, maybe default to cloud
 	}

--- a/packages/cli/cmd/device_connect.go
+++ b/packages/cli/cmd/device_connect.go
@@ -1,0 +1,216 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/babelcloud/gbox/packages/cli/config"
+	"github.com/babelcloud/gbox/packages/cli/internal/device_connect"
+	"github.com/spf13/cobra"
+)
+
+type DeviceConnectOptions struct {
+	DeviceID   string
+	Background bool
+}
+
+// Global client instance
+var deviceClient *device_connect.Client
+
+// getDeviceClient returns the global device client, initializing it if needed
+func getDeviceClient() *device_connect.Client {
+	if deviceClient == nil {
+		deviceClient = device_connect.NewClient(device_connect.DefaultURL)
+	}
+	return deviceClient
+}
+
+func NewDeviceConnectCommand() *cobra.Command {
+	opts := &DeviceConnectOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "device-connect [command] [flags]",
+		Short: "Manage remote connections for local Android development devices",
+		Long: `Manage remote connections for local Android development devices.
+This command allows you to securely connect Android devices (emulators or physical devices) 
+to remote cloud services for remote access and debugging.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ExecuteDeviceConnect(cmd, opts, args)
+		},
+		Example: `  # Interactively select a device to connect
+  gbox device-connect
+
+  # Connect to specific device
+  gbox device-connect --device abc123xyz456-usb
+
+  # Connect device in background
+  gbox device-connect --device abc789pqr012-ip --background
+
+  # List all available devices
+  gbox device-connect ls
+
+  # List devices in JSON format
+  gbox device-connect ls --format json
+
+  # Unregister specific device
+  gbox device-connect unregister abc789pqr012-ip
+
+  # Stop the device proxy service
+  gbox device-connect kill-server`,
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.DeviceID, "device", "d", "", "Specify the Android device ID to connect to")
+	flags.BoolVarP(&opts.Background, "background", "b", false, "Run connection in background")
+
+	cmd.AddCommand(
+		NewDeviceConnectListCommand(),
+		NewDeviceConnectUnregisterCommand(),
+		NewDeviceConnectKillServerCommand(),
+	)
+
+	return cmd
+}
+
+func ExecuteDeviceConnect(cmd *cobra.Command, opts *DeviceConnectOptions, args []string) error {
+	// Ensure device proxy service is running
+	if err := device_connect.EnsureDeviceProxyRunning(isServiceRunning); err != nil {
+		return fmt.Errorf("failed to start device proxy service: %v", err)
+	}
+
+	if opts.DeviceID == "" {
+		return runInteractiveDeviceSelection(opts)
+	}
+	return connectToDevice(opts.DeviceID, opts)
+}
+
+func isServiceRunning() (bool, error) {
+	// First check if PID file exists
+	deviceProxyHome := config.GetDeviceProxyHome()
+	pidFile := filepath.Join(deviceProxyHome, "device-proxy.pid")
+
+	if _, err := os.Stat(pidFile); os.IsNotExist(err) {
+		return false, nil
+	}
+
+	// Read PID from file
+	pidBytes, err := os.ReadFile(pidFile)
+	if err != nil {
+		return false, nil
+	}
+
+	var pid int
+	if _, err := fmt.Sscanf(string(pidBytes), "%d", &pid); err != nil {
+		return false, nil
+	}
+
+	// Check if process is still running
+	if err := exec.Command("kill", "-0", fmt.Sprintf("%d", pid)).Run(); err != nil {
+		// Process is not running, remove PID file
+		os.Remove(pidFile)
+		return false, nil
+	}
+
+	// Try to check service status via API
+	client := getDeviceClient()
+	running, onDemandEnabled, err := client.IsServiceRunning()
+	if err != nil {
+		// If API check fails, assume service is running (we have a valid PID)
+		return true, nil
+	}
+
+	// Check if onDemandEnabled is false and warn user
+	if running && !onDemandEnabled {
+		fmt.Println("Warning: Reusing existing device-proxy service that does not have on-demand registration enabled.")
+		fmt.Println("All devices will be automatically registered for remote access.")
+		fmt.Println("If you don't want this behavior, either:")
+		fmt.Println("  - Stop the existing service and restart with ENABLE_DEVICE_REGISTER_ON_DEMAND=true")
+		fmt.Println("  - Use 'gbox device-connect kill-server' to stop the current service")
+		fmt.Println()
+	}
+
+	return running, nil
+}
+
+func runInteractiveDeviceSelection(opts *DeviceConnectOptions) error {
+	client := getDeviceClient()
+
+	devices, err := client.GetDevices()
+	if err != nil {
+		return fmt.Errorf("failed to get available devices: %v", err)
+	}
+
+	if len(devices) == 0 {
+		fmt.Println("No Android devices found.")
+		return nil
+	}
+
+	fmt.Println("Select a device to register for remote access:")
+	fmt.Println()
+
+	for i, device := range devices {
+		status := "Not Registered"
+		if device.IsRegistrable {
+			status = "Registered"
+		}
+		fmt.Printf("%d. %s (%s, %s) - %s [%s]\n",
+			i+1,
+			device.Udid,
+			device.ProductModel,
+			device.ConnectionType,
+			device.ProductManufacturer,
+			status)
+	}
+
+	fmt.Println()
+	fmt.Print("Enter a number: ")
+
+	var choice int
+	fmt.Scanf("%d", &choice)
+
+	if choice < 1 || choice > len(devices) {
+		return fmt.Errorf("invalid selection: %d", choice)
+	}
+
+	selectedDevice := devices[choice-1]
+	return connectToDevice(selectedDevice.Udid, opts)
+}
+
+func connectToDevice(deviceID string, opts *DeviceConnectOptions) error {
+	client := getDeviceClient()
+
+	device, err := client.GetDeviceInfo(deviceID)
+	if err != nil {
+		return fmt.Errorf("failed to get device info: %v", err)
+	}
+
+	fmt.Printf("Establishing remote connection for %s (%s, %s)...\n",
+		device.ProductModel, device.ConnectionType, device.ProductManufacturer)
+
+	// Register the device
+	if err := client.RegisterDevice(deviceID); err != nil {
+		return fmt.Errorf("failed to register device: %v", err)
+	}
+
+	fmt.Printf("Connection established successfully!\n")
+
+	if opts.Background {
+		fmt.Println("(Running in background. Use 'gbox device-connect unregister' to stop.)")
+		return nil
+	}
+
+	fmt.Println("(Running in foreground. Press Ctrl+C to disconnect.)")
+
+	// Wait for interrupt signal
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	<-sigChan
+	fmt.Printf("Disconnecting %s (%s, %s)...\n",
+		device.ProductModel, device.ConnectionType, device.ProductManufacturer)
+	return client.UnregisterDevice(deviceID)
+}

--- a/packages/cli/cmd/device_connect_kill_server.go
+++ b/packages/cli/cmd/device_connect_kill_server.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/babelcloud/gbox/packages/cli/config"
+	"github.com/babelcloud/gbox/packages/cli/internal/device_connect"
+	"github.com/spf13/cobra"
+)
+
+type DeviceConnectKillServerOptions struct {
+	Force bool
+	All   bool
+}
+
+func NewDeviceConnectKillServerCommand() *cobra.Command {
+	opts := &DeviceConnectKillServerOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "kill-server [flags]",
+		Aliases: []string{"kill"},
+		Short:   "Stop the device proxy service",
+		Long:    "Stop the device proxy service running on port 19925.",
+		Example: `  # Stop the device proxy service gracefully (PID file only)
+  gbox device-connect kill-server
+
+  # Force kill the device proxy service (PID file only)
+  gbox device-connect kill-server --force
+
+  # Kill all device proxy processes (port and name detection)
+  gbox device-connect kill-server --all
+
+  # Force kill all device proxy processes
+  gbox device-connect kill-server --all --force`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ExecuteDeviceConnectKillServer(cmd, opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.Force, "force", "f", false, "Force kill the service process")
+	flags.BoolVarP(&opts.All, "all", "a", false, "Kill all device proxy processes (not just PID file)")
+
+	return cmd
+}
+
+func ExecuteDeviceConnectKillServer(cmd *cobra.Command, opts *DeviceConnectKillServerOptions) error {
+	// Check if PID file exists first
+	deviceProxyHome := config.GetDeviceProxyHome()
+	pidFile := filepath.Join(deviceProxyHome, "device-proxy.pid")
+
+	pidFileExists := false
+	var pidFromFile int
+	if _, err := os.Stat(pidFile); err == nil {
+		pidFileExists = true
+		// Try to read PID from file
+		if pidBytes, err := os.ReadFile(pidFile); err == nil {
+			fmt.Sscanf(string(pidBytes), "%d", &pidFromFile)
+		}
+	}
+
+	// Check if any device-proxy processes are currently running
+	hasRunningProcesses := false
+	if opts.All {
+		portProcesses, _ := device_connect.FindProcessesOnPort(device_connect.DefaultPort)
+		nameProcesses, _ := device_connect.FindGboxDeviceProxyProcesses()
+
+		// Check if there are any actual device-proxy processes
+		for _, pid := range portProcesses {
+			if device_connect.IsDeviceProxyProcess(pid) {
+				hasRunningProcesses = true
+				break
+			}
+		}
+		for range nameProcesses {
+			hasRunningProcesses = true
+			break
+		}
+	} else {
+		// When not using --all, only check if the PID from file is still running
+		if pidFileExists && pidFromFile > 0 {
+			// Check if the process is still running
+			if err := exec.Command("kill", "-0", fmt.Sprintf("%d", pidFromFile)).Run(); err == nil {
+				hasRunningProcesses = true
+			}
+		}
+	}
+
+	// If no processes are running and no PID file exists, report that service is not running
+	if !hasRunningProcesses && !pidFileExists {
+		fmt.Println("Device proxy service is not running.")
+		return nil
+	}
+
+	fmt.Println("Stopping device proxy service...")
+
+	// Method 1: Always try to kill processes using PID file
+	if pidFileExists {
+		// PID file exists, try to kill the process
+		pidBytes, err := os.ReadFile(pidFile)
+		if err == nil {
+			var pid int
+			if _, err := fmt.Sscanf(string(pidBytes), "%d", &pid); err == nil {
+				if err := device_connect.KillProcess(pid, opts.Force); err == nil {
+					fmt.Printf("Killed process %d from PID file\n", pid)
+				} else {
+					fmt.Printf("Warning: failed to kill process %d from PID file: %v\n", pid, err)
+				}
+			}
+		}
+		// Remove PID file regardless of success
+		os.Remove(pidFile)
+	}
+
+	// Only use port and name-based killing when --all flag is set
+	if opts.All {
+		// Method 2: Find and kill processes by port, but only if they are device-proxy processes
+		portProcesses, err := device_connect.FindProcessesOnPort(device_connect.DefaultPort)
+		if err == nil && len(portProcesses) > 0 {
+			for _, pid := range portProcesses {
+				// Check if this process is actually a device-proxy process
+				if device_connect.IsDeviceProxyProcess(pid) {
+					if err := device_connect.KillProcess(pid, opts.Force); err == nil {
+						fmt.Printf("Killed process %d using port %d\n", pid, device_connect.DefaultPort)
+					} else {
+						fmt.Printf("Warning: failed to kill process %d using port %d: %v\n", pid, device_connect.DefaultPort, err)
+					}
+				}
+			}
+		}
+
+		// Method 3: Find and kill processes by name
+		nameProcesses, err := device_connect.FindGboxDeviceProxyProcesses()
+		if err == nil && len(nameProcesses) > 0 {
+			for _, pid := range nameProcesses {
+				if err := device_connect.KillProcess(pid, opts.Force); err == nil {
+					fmt.Printf("Killed process %d by name\n", pid)
+				} else {
+					fmt.Printf("Warning: failed to kill process %d by name: %v\n", pid, err)
+				}
+			}
+		}
+	}
+
+	// Check if any device-proxy processes are still running (only when --all is used)
+	if opts.All {
+		remainingPortProcesses, _ := device_connect.FindProcessesOnPort(device_connect.DefaultPort)
+		remainingNameProcesses, _ := device_connect.FindGboxDeviceProxyProcesses()
+
+		// Filter out non-device-proxy processes from port processes
+		var deviceProxyPortProcesses []int
+		for _, pid := range remainingPortProcesses {
+			if device_connect.IsDeviceProxyProcess(pid) {
+				deviceProxyPortProcesses = append(deviceProxyPortProcesses, pid)
+			}
+		}
+
+		if len(deviceProxyPortProcesses) == 0 && len(remainingNameProcesses) == 0 {
+			fmt.Println("Device proxy service stopped successfully.")
+			return nil
+		} else {
+			fmt.Println("Warning: Some device proxy processes may still be running:")
+
+			// Show device-proxy processes found by port
+			if len(deviceProxyPortProcesses) > 0 {
+				fmt.Printf("  Device proxy processes using port %d:\n", device_connect.DefaultPort)
+				for _, pid := range deviceProxyPortProcesses {
+					if cmd, err := device_connect.GetProcessCommand(pid); err == nil {
+						fmt.Printf("    PID %d: %s\n", pid, cmd)
+					} else {
+						fmt.Printf("    PID %d: <command not available>\n", pid)
+					}
+				}
+			}
+
+			// Show processes found by name
+			if len(remainingNameProcesses) > 0 {
+				fmt.Println("  Device proxy processes found by name:")
+				for _, pid := range remainingNameProcesses {
+					if cmd, err := device_connect.GetProcessCommand(pid); err == nil {
+						fmt.Printf("    PID %d: %s\n", pid, cmd)
+					} else {
+						fmt.Printf("    PID %d: <command not available>\n", pid)
+					}
+				}
+			}
+
+			fmt.Println("Use 'gbox device-connect kill-server --all --force' to force kill all remaining processes.")
+			return nil
+		}
+	} else {
+		// When not using --all, just report success if PID file was handled
+		fmt.Println("Device proxy service stopped successfully.")
+		return nil
+	}
+}

--- a/packages/cli/cmd/device_connect_list.go
+++ b/packages/cli/cmd/device_connect_list.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/babelcloud/gbox/packages/cli/internal/device_connect"
+	"github.com/spf13/cobra"
+)
+
+const (
+	statusRegistered    = "Registered"
+	statusNotRegistered = "Not Registered"
+	deviceTypeDevice    = "device"
+	deviceTypeEmulator  = "emulator"
+)
+
+type DeviceConnectListOptions struct {
+	OutputFormat string
+}
+
+func NewDeviceConnectListCommand() *cobra.Command {
+	opts := &DeviceConnectListOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "ls [flags]",
+		Aliases: []string{"list"},
+		Short:   "List all detectable local Android devices and their registration status",
+		Long:    "List all detectable local Android devices and their registration status.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ExecuteDeviceConnectList(cmd, opts)
+		},
+		Example: `  # List all local Android devices and their registration status (default text format):
+  gbox device-connect ls
+
+  # List all local Android devices and their registration status in JSON format:
+  gbox device-connect ls --format json`,
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.OutputFormat, "format", "", "text", "Specify output format. Options are \"text\" (default) or \"json\".")
+
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"text", "json"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	return cmd
+}
+
+func ExecuteDeviceConnectList(cmd *cobra.Command, opts *DeviceConnectListOptions) error {
+	// Ensure device proxy service is running
+	if err := device_connect.EnsureDeviceProxyRunning(isServiceRunning); err != nil {
+		return fmt.Errorf("failed to start device proxy service: %v", err)
+	}
+
+	client := getDeviceClient()
+
+	devices, err := client.GetDevices()
+	if err != nil {
+		return fmt.Errorf("failed to get available devices: %v", err)
+	}
+
+	if opts.OutputFormat == "json" {
+		return outputDevicesJSON(devices)
+	}
+
+	return outputDevicesText(devices)
+}
+
+func outputDevicesJSON(devices []device_connect.DeviceInfo) error {
+	// Create a simplified JSON output for compatibility
+	type SimpleDeviceInfo struct {
+		DeviceID         string `json:"device_id"`
+		Name             string `json:"name"`
+		Type             string `json:"type"`
+		ConnectionStatus string `json:"connection_status"`
+	}
+
+	var simpleDevices []SimpleDeviceInfo
+	for _, device := range devices {
+		status := statusNotRegistered
+		if device.IsRegistrable {
+			status = statusRegistered
+		}
+
+		deviceType := deviceTypeDevice
+		// Check if it's an emulator based on serial number
+		if strings.Contains(strings.ToUpper(device.SerialNo), "EMULATOR") {
+			deviceType = deviceTypeEmulator
+		}
+
+		simpleDevices = append(simpleDevices, SimpleDeviceInfo{
+			DeviceID:         device.Udid,
+			Name:             device.ProductModel,
+			Type:             deviceType,
+			ConnectionStatus: status,
+		})
+	}
+
+	jsonBytes, err := json.MarshalIndent(simpleDevices, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal devices to JSON: %v", err)
+	}
+	fmt.Println(string(jsonBytes))
+	return nil
+}
+
+func outputDevicesText(devices []device_connect.DeviceInfo) error {
+	if len(devices) == 0 {
+		fmt.Println("No Android devices found.")
+		return nil
+	}
+
+	// Calculate column widths based on content
+	deviceIDWidth := len("DEVICE ID")
+	nameWidth := len("NAME")
+	typeWidth := len("TYPE")
+	statusWidth := len("STATUS")
+
+	// Find maximum widths for each column
+	for _, device := range devices {
+		if len(device.Udid) > deviceIDWidth {
+			deviceIDWidth = len(device.Udid)
+		}
+		if len(device.ProductModel) > nameWidth {
+			nameWidth = len(device.ProductModel)
+		}
+		if len(deviceTypeEmulator) > typeWidth {
+			typeWidth = len(deviceTypeEmulator)
+		}
+		if len(statusNotRegistered) > statusWidth {
+			statusWidth = len(statusNotRegistered)
+		}
+	}
+
+	// Add some padding
+	deviceIDWidth += 2
+	nameWidth += 2
+	typeWidth += 2
+	statusWidth += 2
+
+	// Print header
+	fmt.Printf("%-*s %-*s %-*s %-*s\n",
+		deviceIDWidth, "DEVICE ID",
+		nameWidth, "NAME",
+		typeWidth, "TYPE",
+		statusWidth, "STATUS")
+
+	// Print data rows
+	for _, device := range devices {
+		status := statusNotRegistered
+		if device.IsRegistrable {
+			status = statusRegistered
+		}
+
+		deviceType := deviceTypeDevice
+		// Check if it's an emulator based on serial number
+		if strings.Contains(strings.ToUpper(device.SerialNo), "EMULATOR") {
+			deviceType = deviceTypeEmulator
+		}
+
+		fmt.Printf("%-*s %-*s %-*s %-*s\n",
+			deviceIDWidth, device.Udid,
+			nameWidth, device.ProductModel,
+			typeWidth, deviceType,
+			statusWidth, status)
+	}
+
+	return nil
+}

--- a/packages/cli/cmd/device_connect_unregister.go
+++ b/packages/cli/cmd/device_connect_unregister.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/babelcloud/gbox/packages/cli/internal/device_connect"
+	"github.com/spf13/cobra"
+)
+
+type DeviceConnectUnregisterOptions struct {
+	All bool
+}
+
+func NewDeviceConnectUnregisterCommand() *cobra.Command {
+	opts := &DeviceConnectUnregisterOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "unregister [device_id] [flags]",
+		Aliases: []string{"unreg"},
+		Short:   "Unregister one or all active gbox device connections",
+		Long:    "Unregister one or all active gbox device connections.",
+		Example: `  # Unregister device with specific device ID:
+  gbox device-connect unregister abc789pqr012-ip
+
+  # Unregister all active device connections:
+  gbox device-connect unregister --all`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ExecuteDeviceConnectUnregister(cmd, opts, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.All, "all", "a", false, "Disconnect all active device connections")
+
+	return cmd
+}
+
+func ExecuteDeviceConnectUnregister(cmd *cobra.Command, opts *DeviceConnectUnregisterOptions, args []string) error {
+	if opts.All {
+		return unregisterAllDevices()
+	}
+
+	if len(args) == 0 {
+		return runInteractiveUnregisterSelection()
+	}
+
+	deviceID := args[0]
+	return unregisterDevice(deviceID)
+}
+
+func unregisterAllDevices() error {
+	client := getDeviceClient()
+
+	devices, err := client.GetDevices()
+	if err != nil {
+		return fmt.Errorf("failed to get available devices: %v", err)
+	}
+
+	unregisteredCount := 0
+	for _, device := range devices {
+		if device.IsRegistrable {
+			fmt.Printf("Unregistering %s (%s, %s)...\n",
+				device.Udid, device.ProductModel, device.ConnectionType)
+
+			if err := client.UnregisterDevice(device.Udid); err != nil {
+				fmt.Printf("Failed to unregister %s: %v\n", device.Udid, err)
+				continue
+			}
+
+			fmt.Printf("Device %s unregistered successfully.\n", device.Udid)
+			unregisteredCount++
+		}
+	}
+
+	if unregisteredCount == 0 {
+		fmt.Println("No active connections found to unregister.")
+	} else {
+		fmt.Printf("Unregistered %d device(s).\n", unregisteredCount)
+	}
+
+	return nil
+}
+
+func unregisterDevice(deviceID string) error {
+	client := getDeviceClient()
+
+	device, err := client.GetDeviceInfo(deviceID)
+	if err != nil {
+		return fmt.Errorf("device not found: %s", deviceID)
+	}
+
+	fmt.Printf("Unregistering %s (%s, %s)...\n",
+		deviceID, device.ProductModel, device.ConnectionType)
+
+	if err := client.UnregisterDevice(deviceID); err != nil {
+		return fmt.Errorf("failed to unregister device: %v", err)
+	}
+
+	fmt.Printf("Device %s unregistered successfully.\n", deviceID)
+
+	return nil
+}
+
+func runInteractiveUnregisterSelection() error {
+	client := getDeviceClient()
+
+	devices, err := client.GetDevices()
+	if err != nil {
+		return fmt.Errorf("failed to get available devices: %v", err)
+	}
+
+	// Filter only registered devices
+	var registeredDevices []device_connect.DeviceInfo
+	for _, device := range devices {
+		if device.IsRegistrable {
+			registeredDevices = append(registeredDevices, device)
+		}
+	}
+
+	if len(registeredDevices) == 0 {
+		fmt.Println("No active device connections found.")
+		return nil
+	}
+
+	fmt.Println("Select a device to unregister:")
+	fmt.Println()
+
+	for i, device := range registeredDevices {
+		fmt.Printf("%d. %s (%s, %s) - %s\n",
+			i+1,
+			device.Udid,
+			device.ProductModel,
+			device.ConnectionType,
+			device.ProductManufacturer)
+	}
+
+	fmt.Println()
+	fmt.Print("Enter a number: ")
+
+	var choice int
+	fmt.Scanf("%d", &choice)
+
+	if choice < 1 || choice > len(registeredDevices) {
+		return fmt.Errorf("invalid selection: %d", choice)
+	}
+
+	selectedDevice := registeredDevices[choice-1]
+	return unregisterDevice(selectedDevice.Udid)
+}

--- a/packages/cli/cmd/login.go
+++ b/packages/cli/cmd/login.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/babelcloud/gbox/packages/cli/config"
 	"github.com/babelcloud/gbox/packages/cli/internal/cloud"
+	"github.com/babelcloud/gbox/packages/cli/internal/profile"
 
 	"os/exec"
 	"runtime"
@@ -297,7 +298,7 @@ func getLocalToken(githubToken string) (string, error) {
 
 	// Save API key related data to profile.json
 	if apiKeyInfo != nil && selectedOrg != nil {
-		pm := NewProfileManager()
+		pm := profile.NewProfileManager()
 		if err := pm.Load(); err != nil {
 			return "", fmt.Errorf("failed to load profile manager: %v", err)
 		}

--- a/packages/cli/cmd/port_forward.go
+++ b/packages/cli/cmd/port_forward.go
@@ -18,6 +18,7 @@ import (
 	"github.com/babelcloud/gbox/packages/cli/config"
 	"github.com/babelcloud/gbox/packages/cli/internal/gboxsdk"
 	port_forward "github.com/babelcloud/gbox/packages/cli/internal/port-forward"
+	"github.com/babelcloud/gbox/packages/cli/internal/profile"
 	"github.com/spf13/cobra"
 )
 
@@ -171,7 +172,7 @@ func ExecutePortForward(cmd *cobra.Command, opts *PortForwardOptions, args []str
 	}
 
 	// try to get API_KEY, if not set, return error
-	pm := NewProfileManager()
+	pm := profile.NewProfileManager()
 	if err := pm.Load(); err != nil {
 		return fmt.Errorf("Failed to load profile: %v", err)
 	}

--- a/packages/cli/cmd/root.go
+++ b/packages/cli/cmd/root.go
@@ -75,6 +75,7 @@ func init() {
 	rootCmd.AddCommand(NewCuaCommand())
 	rootCmd.AddCommand(NewVersionCommand())
 	rootCmd.AddCommand(NewPortForwardCommand())
+	rootCmd.AddCommand(NewDeviceConnectCommand())
 }
 
 func createAliasCommand(alias, targetCmd string) {

--- a/packages/cli/internal/device_connect/client.go
+++ b/packages/cli/internal/device_connect/client.go
@@ -1,0 +1,188 @@
+package device_connect
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	DefaultPort = 19925
+	DefaultURL  = "http://localhost:19925"
+)
+
+// DeviceInfo represents a device from the API
+type DeviceInfo struct {
+	Udid                string `json:"udid"`
+	State               string `json:"state"`
+	Interfaces          []struct {
+		Name string `json:"name"`
+		Ipv4 string `json:"ipv4"`
+	} `json:"interfaces"`
+	Pid                 int    `json:"pid"`
+	BuildVersionRelease string `json:"ro.build.version.release"`
+	BuildVersionSdk     string `json:"ro.build.version.sdk"`
+	ProductManufacturer string `json:"ro.product.manufacturer"`
+	ProductModel        string `json:"ro.product.model"`
+	ProductCpuAbi       string `json:"ro.product.cpu.abi"`
+	SerialNo            string `json:"ro.serialno"`
+	LastUpdateTimestamp int64  `json:"last.update.timestamp"`
+	ConnectionType      string `json:"connectionType"`
+	IsRegistrable       bool   `json:"isRegistrable"`
+}
+
+// DeviceListResponse represents the response from GET /api/devices
+type DeviceListResponse struct {
+	Success           bool         `json:"success"`
+	Devices           []DeviceInfo `json:"devices"`
+	OnDemandEnabled   bool         `json:"onDemandEnabled"`
+	Error             string       `json:"error,omitempty"`
+}
+
+// DeviceActionResponse represents the response from POST /api/devices/register and /api/devices/unregister
+type DeviceActionResponse struct {
+	Success   bool   `json:"success"`
+	Message   string `json:"message,omitempty"`
+	DeviceID  string `json:"device_id,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// Client represents a device proxy API client
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewClient creates a new device proxy API client
+func NewClient(baseURL string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// IsServiceRunning checks if the device proxy service is running and returns onDemandEnabled status
+func (c *Client) IsServiceRunning() (bool, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/api/devices", c.baseURL), nil)
+	if err != nil {
+		return false, false, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, false, fmt.Errorf("service returned status code: %d", resp.StatusCode)
+	}
+
+	// Parse response to check onDemandEnabled status
+	var deviceListResp DeviceListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&deviceListResp); err != nil {
+		return false, false, fmt.Errorf("failed to parse response: %v", err)
+	}
+
+	if !deviceListResp.Success {
+		return false, false, fmt.Errorf("API returned success: false")
+	}
+
+	return true, deviceListResp.OnDemandEnabled, nil
+}
+
+// GetDevices retrieves all available devices from the API
+func (c *Client) GetDevices() ([]DeviceInfo, error) {
+	resp, err := c.httpClient.Get(fmt.Sprintf("%s/api/devices", c.baseURL))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var deviceListResp DeviceListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&deviceListResp); err != nil {
+		return nil, err
+	}
+
+	if !deviceListResp.Success {
+		return nil, fmt.Errorf("API error: %s", deviceListResp.Error)
+	}
+
+	return deviceListResp.Devices, nil
+}
+
+// GetDeviceInfo retrieves information about a specific device
+func (c *Client) GetDeviceInfo(deviceID string) (*DeviceInfo, error) {
+	devices, err := c.GetDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, device := range devices {
+		if device.Udid == deviceID {
+			return &device, nil
+		}
+	}
+
+	return nil, fmt.Errorf("device not found: %s", deviceID)
+}
+
+// RegisterDevice registers a device for remote access
+func (c *Client) RegisterDevice(deviceID string) error {
+	data := map[string]string{"deviceId": deviceID}
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.httpClient.Post(fmt.Sprintf("%s/api/devices/register", c.baseURL), "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var deviceActionResp DeviceActionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&deviceActionResp); err != nil {
+		return err
+	}
+
+	if !deviceActionResp.Success {
+		return fmt.Errorf("failed to register device: %s", deviceActionResp.Error)
+	}
+
+	return nil
+}
+
+// UnregisterDevice unregisters a device
+func (c *Client) UnregisterDevice(deviceID string) error {
+	data := map[string]string{"deviceId": deviceID}
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.httpClient.Post(fmt.Sprintf("%s/api/devices/unregister", c.baseURL), "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var deviceActionResp DeviceActionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&deviceActionResp); err != nil {
+		return err
+	}
+
+	if !deviceActionResp.Success {
+		return fmt.Errorf("failed to unregister device: %s", deviceActionResp.Error)
+	}
+
+	return nil
+} 

--- a/packages/cli/internal/device_connect/daemon.go
+++ b/packages/cli/internal/device_connect/daemon.go
@@ -1,0 +1,185 @@
+package device_connect
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"time"
+
+	"github.com/babelcloud/gbox/packages/cli/config"
+	"github.com/babelcloud/gbox/packages/cli/internal/profile"
+)
+
+// EnsureDeviceProxyRunning checks if the service is running, and starts it if not
+func EnsureDeviceProxyRunning(isServiceRunning func() (bool, error)) error {
+	running, err := isServiceRunning()
+	if err != nil {
+		return StartDeviceProxyService()
+	}
+	if running {
+		return nil
+	}
+	return StartDeviceProxyService()
+}
+
+func StartDeviceProxyService() error {
+	binaryPath, err := FindDeviceProxyBinary()
+	if err != nil {
+		return fmt.Errorf("device proxy binary not found: %v", err)
+	}
+
+	// Create device proxy home directory
+	deviceProxyHome := config.GetDeviceProxyHome()
+	if err := os.MkdirAll(deviceProxyHome, 0755); err != nil {
+		return fmt.Errorf("failed to create device proxy home directory: %v", err)
+	}
+
+	// Create log file
+	logFile := filepath.Join(deviceProxyHome, "device-proxy.log")
+	logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create log file: %v", err)
+	}
+	defer logFd.Close()
+
+	// Create PID file path
+	pidFile := filepath.Join(deviceProxyHome, "device-proxy.pid")
+
+	// Get API key from current profile
+	apiKey, err := profile.GetCurrentAPIKey()
+	if err != nil {
+		return fmt.Errorf("failed to get API key: %v", err)
+	}
+
+	// Set up environment variables
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("GBOX_API_KEY=%s", apiKey))
+
+	cmd := exec.Command(binaryPath, "--port", "19925", "--on-demand")
+	cmd.Stdout = logFd
+	cmd.Stderr = logFd
+	cmd.Env = env
+
+	// Set process group to make child process independent
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+
+	// Start the process
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start device proxy service: %v", err)
+	}
+
+	// Write PID to file
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0644); err != nil {
+		// Try to kill the process if we can't write PID file
+		cmd.Process.Kill()
+		return fmt.Errorf("failed to write PID file: %v", err)
+	}
+
+	time.Sleep(2 * time.Second)
+	return nil
+}
+
+func FindDeviceProxyBinary() (string, error) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current directory: %v", err)
+	}
+	executablePath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to get executable path: %v", err)
+	}
+	executableDir := filepath.Dir(executablePath)
+	osName := runtime.GOOS
+	arch := runtime.GOARCH
+
+	// Map OS names to match the actual binary naming convention
+	binaryOSName := osName
+	if osName == "darwin" {
+		binaryOSName = "macos"
+	}
+
+	specificBinary := fmt.Sprintf("gbox-device-proxy-%s-%s", binaryOSName, arch)
+	if osName == "windows" {
+		specificBinary += ".exe"
+	}
+	genericBinary := "gbox-device-proxy"
+	if osName == "windows" {
+		genericBinary += ".exe"
+	}
+
+	// Search in current directory hierarchy
+	searchPaths := []string{}
+	current := currentDir
+	for {
+		searchPaths = append(searchPaths, filepath.Join(current, specificBinary))
+		searchPaths = append(searchPaths, filepath.Join(current, genericBinary))
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			break // Reached root directory
+		}
+		current = parent
+	}
+
+	// Also search in executable directory hierarchy
+	execCurrent := executableDir
+	for {
+		searchPaths = append(searchPaths, filepath.Join(execCurrent, specificBinary))
+		searchPaths = append(searchPaths, filepath.Join(execCurrent, genericBinary))
+
+		parent := filepath.Dir(execCurrent)
+		if parent == execCurrent {
+			break // Reached root directory
+		}
+		execCurrent = parent
+	}
+
+	// First, try to find binary in babel-umbrella directory
+	babelUmbrellaPath := FindBabelUmbrellaDir(currentDir)
+	if babelUmbrellaPath != "" {
+		binariesDir := filepath.Join(babelUmbrellaPath, "gbox-device-proxy", "build", "binaries")
+		babelBinaryPath := filepath.Join(binariesDir, specificBinary)
+		if _, err := os.Stat(babelBinaryPath); err == nil {
+			return babelBinaryPath, nil
+		}
+		if _, err := os.Stat(filepath.Join(binariesDir, genericBinary)); err == nil {
+			return filepath.Join(binariesDir, genericBinary), nil
+		}
+	}
+
+	for _, path := range searchPaths {
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("gbox-device-proxy binary not found. Please build it first using 'npm run build' in the gbox-device-proxy directory")
+}
+
+func FindBabelUmbrellaDir(startDir string) string {
+	current := startDir
+
+	// First, try to find babel-umbrella in the current path hierarchy
+	for {
+		if filepath.Base(current) == "babel-umbrella" {
+			return current
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+
+	// If not found in hierarchy, try the known relative path
+	knownPath := filepath.Join(startDir, "..", "..", "..", "babel-umbrella")
+	if _, err := os.Stat(knownPath); err == nil {
+		return knownPath
+	}
+
+	return ""
+}

--- a/packages/cli/internal/device_connect/kill.go
+++ b/packages/cli/internal/device_connect/kill.go
@@ -1,0 +1,197 @@
+package device_connect
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// FindProcessesOnPort finds processes using a specific port
+func FindProcessesOnPort(port int) ([]int, error) {
+	var cmd *exec.Cmd
+	var output []byte
+	var err error
+
+	switch runtime.GOOS {
+	case "darwin", "linux":
+		// Use lsof to find processes using the port
+		cmd = exec.Command("lsof", "-ti", fmt.Sprintf(":%d", port))
+		output, err = cmd.Output()
+		if err != nil {
+			// If lsof fails, try to find gbox-device-proxy processes by name
+			return FindGboxDeviceProxyProcesses()
+		}
+		return parseLsofOutput(string(output))
+	case "windows":
+		// Use netstat on Windows
+		cmd = exec.Command("netstat", "-ano")
+		output, err = cmd.Output()
+		if err != nil {
+			return nil, fmt.Errorf("failed to find processes on port %d: %v", port, err)
+		}
+		return parseWindowsNetstatOutput(string(output), port)
+	default:
+		return nil, fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	}
+}
+
+func parseLsofOutput(output string) ([]int, error) {
+	if output == "" {
+		return []int{}, nil
+	}
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	var pids []int
+
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var pid int
+		if _, err := fmt.Sscanf(line, "%d", &pid); err == nil {
+			pids = append(pids, pid)
+		}
+	}
+
+	return pids, nil
+}
+
+func parseNetstatOutput(output string, port int) ([]int, error) {
+	lines := strings.Split(output, "\n")
+	var pids []int
+
+	for _, line := range lines {
+		if strings.Contains(line, fmt.Sprintf(":%d", port)) {
+			// Extract PID from the last field
+			fields := strings.Fields(line)
+			if len(fields) > 0 {
+				lastField := fields[len(fields)-1]
+				if strings.Contains(lastField, "/") {
+					parts := strings.Split(lastField, "/")
+					if len(parts) > 0 {
+						var pid int
+						if _, err := fmt.Sscanf(parts[0], "%d", &pid); err == nil {
+							pids = append(pids, pid)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return pids, nil
+}
+
+func parseWindowsNetstatOutput(output string, port int) ([]int, error) {
+	lines := strings.Split(output, "\n")
+	var pids []int
+
+	for _, line := range lines {
+		if strings.Contains(line, fmt.Sprintf(":%d", port)) {
+			// Extract PID from the last field
+			fields := strings.Fields(line)
+			if len(fields) > 0 {
+				lastField := fields[len(fields)-1]
+				var pid int
+				if _, err := fmt.Sscanf(lastField, "%d", &pid); err == nil {
+					pids = append(pids, pid)
+				}
+			}
+		}
+	}
+
+	return pids, nil
+}
+
+func FindGboxDeviceProxyProcesses() ([]int, error) {
+	// Use ps to find gbox-device-proxy processes
+	cmd := exec.Command("ps", "-ef")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find gbox-device-proxy processes: %v", err)
+	}
+
+	lines := strings.Split(string(output), "\n")
+	var pids []int
+
+	for _, line := range lines {
+		if strings.Contains(line, "gbox-device-proxy") && !strings.Contains(line, "grep") {
+			fields := strings.Fields(line)
+			if len(fields) > 1 {
+				var pid int
+				if _, err := fmt.Sscanf(fields[1], "%d", &pid); err == nil {
+					pids = append(pids, pid)
+				}
+			}
+		}
+	}
+
+	return pids, nil
+}
+
+// KillProcess kills a process by PID
+func KillProcess(pid int, force bool) error {
+	var cmd *exec.Cmd
+
+	if force {
+		switch runtime.GOOS {
+		case "darwin", "linux":
+			cmd = exec.Command("kill", "-9", fmt.Sprintf("%d", pid))
+		case "windows":
+			cmd = exec.Command("taskkill", "/F", "/PID", fmt.Sprintf("%d", pid))
+		default:
+			return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+		}
+	} else {
+		switch runtime.GOOS {
+		case "darwin", "linux":
+			cmd = exec.Command("kill", fmt.Sprintf("%d", pid))
+		case "windows":
+			cmd = exec.Command("taskkill", "/PID", fmt.Sprintf("%d", pid))
+		default:
+			return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+		}
+	}
+
+	return cmd.Run()
+}
+
+// GetProcessCommand returns the command and arguments for a given process ID
+func GetProcessCommand(pid int) (string, error) {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("ps", "-p", fmt.Sprintf("%d", pid), "-o", "command=")
+	case "linux":
+		cmd = exec.Command("ps", "-p", fmt.Sprintf("%d", pid), "-o", "args=")
+	case "windows":
+		cmd = exec.Command("wmic", "process", "where", fmt.Sprintf("ProcessId=%d", pid), "get", "CommandLine", "/value")
+	default:
+		return "", fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	command := strings.TrimSpace(string(output))
+	if command == "" {
+		return "", fmt.Errorf("no command found for PID %d", pid)
+	}
+
+	return command, nil
+}
+
+// IsDeviceProxyProcess checks if a process is a device-proxy process by examining its command
+func IsDeviceProxyProcess(pid int) bool {
+	command, err := GetProcessCommand(pid)
+	if err != nil {
+		return false
+	}
+
+	// Check if the command contains "gbox-device-proxy"
+	return strings.Contains(command, "gbox-device-proxy")
+}

--- a/packages/cli/internal/profile/mgr.go
+++ b/packages/cli/internal/profile/mgr.go
@@ -1,0 +1,229 @@
+package profile
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/babelcloud/gbox/packages/cli/config"
+)
+
+// Profile represents a configuration item
+type Profile struct {
+	APIKey           string `json:"api_key"`
+	Name             string `json:"name"`
+	OrganizationName string `json:"organization_name"`
+	Current          bool   `json:"current"`
+}
+
+// ProfileManager manages profile files
+type ProfileManager struct {
+	profiles []Profile
+	path     string
+}
+
+// NewProfileManager creates a new ProfileManager
+func NewProfileManager() *ProfileManager {
+	return &ProfileManager{
+		profiles: []Profile{},
+		path:     config.GetProfilePath(),
+	}
+}
+
+// Load loads profiles from file
+func (pm *ProfileManager) Load() error {
+	if _, err := os.Stat(pm.path); os.IsNotExist(err) {
+		// File doesn't exist, create empty file
+		return pm.Save()
+	}
+
+	data, err := os.ReadFile(pm.path)
+	if err != nil {
+		return fmt.Errorf("failed to read profile file: %v", err)
+	}
+
+	if len(data) == 0 {
+		pm.profiles = []Profile{}
+		return nil
+	}
+
+	if err := json.Unmarshal(data, &pm.profiles); err != nil {
+		return fmt.Errorf("failed to parse profile file: %v", err)
+	}
+
+	return nil
+}
+
+// Save saves profiles to file
+func (pm *ProfileManager) Save() error {
+	if err := os.MkdirAll(filepath.Dir(pm.path), 0o755); err != nil {
+		return fmt.Errorf("failed to create config directory: %v", err)
+	}
+
+	data, err := json.MarshalIndent(pm.profiles, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize profile data: %v", err)
+	}
+
+	if err := os.WriteFile(pm.path, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write profile file: %v", err)
+	}
+
+	return nil
+}
+
+// List lists all profiles
+func (pm *ProfileManager) List() {
+	if len(pm.profiles) == 0 {
+		fmt.Println("No profiles found")
+		return
+	}
+
+	fmt.Println("Profiles:")
+	fmt.Println("--------")
+	for i, profile := range pm.profiles {
+		current := ""
+		if profile.Current {
+			current = " (*)"
+		}
+		fmt.Printf("%d. %s - %s%s\n", i+1, profile.Name, profile.OrganizationName, current)
+	}
+}
+
+// Add adds a new profile
+func (pm *ProfileManager) Add(apiKey, name, organizationName string) error {
+	// Check if the same profile already exists
+	for _, profile := range pm.profiles {
+		if profile.APIKey == apiKey && profile.Name == name && profile.OrganizationName == organizationName {
+			return fmt.Errorf("same profile already exists")
+		}
+	}
+
+	// Clear current flag from all profiles
+	for i := range pm.profiles {
+		pm.profiles[i].Current = false
+	}
+
+	// Add new profile and set as current
+	newProfile := Profile{
+		APIKey:           apiKey,
+		Name:             name,
+		OrganizationName: organizationName,
+		Current:          true,
+	}
+
+	pm.profiles = append(pm.profiles, newProfile)
+
+	return pm.Save()
+}
+
+// Use sets the current profile
+func (pm *ProfileManager) Use(index int) error {
+	if len(pm.profiles) == 0 {
+		return fmt.Errorf("no profiles available, please add a profile first")
+	}
+
+	// If index is 0, show selection menu
+	if index == 0 {
+		fmt.Println("Available Profiles:")
+		fmt.Println("------------------")
+		for i, profile := range pm.profiles {
+			current := ""
+			if profile.Current {
+				current = " (*)"
+			}
+			fmt.Printf("%d. %s - %s%s\n", i+1, profile.Name, profile.OrganizationName, current)
+		}
+		fmt.Print("\nPlease select a profile (enter number): ")
+
+		var input string
+		fmt.Scanln(&input)
+
+		var err error
+		index, err = strconv.Atoi(input)
+		if err != nil {
+			return fmt.Errorf("invalid input: %s", input)
+		}
+	}
+
+	if index < 1 || index > len(pm.profiles) {
+		return fmt.Errorf("invalid profile index: %d", index)
+	}
+
+	// Clear current flag from all profiles
+	for i := range pm.profiles {
+		pm.profiles[i].Current = false
+	}
+
+	// Set specified profile as current
+	pm.profiles[index-1].Current = true
+
+	return pm.Save()
+}
+
+// Remove removes the specified profile
+func (pm *ProfileManager) Remove(index int) error {
+	if index < 1 || index > len(pm.profiles) {
+		return fmt.Errorf("invalid profile index: %d", index)
+	}
+
+	// Check if trying to delete current profile
+	if pm.profiles[index-1].Current && len(pm.profiles) > 1 {
+		return fmt.Errorf("cannot delete the currently active profile, please switch to another profile first")
+	}
+
+	// Remove specified profile
+	pm.profiles = append(pm.profiles[:index-1], pm.profiles[index:]...)
+
+	// If there are still profiles after deletion and no current profile, set the first one as current
+	if len(pm.profiles) > 0 {
+		hasCurrent := false
+		for _, profile := range pm.profiles {
+			if profile.Current {
+				hasCurrent = true
+				break
+			}
+		}
+		if !hasCurrent {
+			pm.profiles[0].Current = true
+		}
+	}
+
+	return pm.Save()
+}
+
+// GetCurrent gets the current profile
+func (pm *ProfileManager) GetCurrent() *Profile {
+	for _, profile := range pm.profiles {
+		if profile.Current {
+			return &profile
+		}
+	}
+	return nil
+}
+
+// GetProfiles returns all profiles
+func (pm *ProfileManager) GetProfiles() []Profile {
+	return pm.profiles
+}
+
+// GetCurrentAPIKey gets the API key from the current profile
+func GetCurrentAPIKey() (string, error) {
+	pm := NewProfileManager()
+	if err := pm.Load(); err != nil {
+		return "", fmt.Errorf("failed to load profiles: %v", err)
+	}
+
+	current := pm.GetCurrent()
+	if current == nil {
+		return "", fmt.Errorf("no current profile set. Please run 'gbox profile use' to set a current profile first")
+	}
+
+	if current.APIKey == "" {
+		return "", fmt.Errorf("current profile has no API key. Please run 'gbox profile add' to configure a profile first")
+	}
+
+	return current.APIKey, nil
+}


### PR DESCRIPTION
- Introduced 'device-connect' command for Android devices.
- Added subcommands: 'ls', 'unregister', 'kill-server'.
- Integrated profile management with API key usage.
- Refactored to use 'ProfileManager' for better organization.

Enhances CLI's capability for device connections.

## User experience workthrough
```bash
❯ gbox device-connect
Select a device to register for remote access:

1. emulator-5554 (sdk_gphone64_arm64, usb) - Google [Not Registered]
2. A4RYVB3A20008848 (REA-AN00, usb) - HONOR [Not Registered]

Enter a number: 2
Establishing remote connection for REA-AN00 (usb, HONOR)...
Connection established successfully!
(Running in foreground. Press Ctrl+C to disconnect.)
```

```bash
❯ gbox device-connect ls
DEVICE ID          NAME                 TYPE       STATUS          
emulator-5554      sdk_gphone64_arm64   emulator   Not Registered  
A4RYVB3A20008848   REA-AN00             device     Registered  
```

```bash
❯ gbox device-connect unreg
Select a device to unregister:

1. A4RYVB3A20008848 (REA-AN00, usb) - HONOR

Enter a number: 1
Unregistering A4RYVB3A20008848 (REA-AN00, usb)...
Device A4RYVB3A20008848 unregistered successfully.
```

```bash
❯ gbox device-connect kill-server
Stopping device proxy service...
Killed process 5606 from PID file
Device proxy service stopped successfully.
```

## Help
```bash
❯ gbox device-connect --help
Manage remote connections for local Android development devices.
This command allows you to securely connect Android devices (emulators or physical devices) 
to remote cloud services for remote access and debugging.

Usage:
  gbox device-connect [command] [flags]
  gbox device-connect [command]

Examples:
  # Interactively select a device to connect
  gbox device-connect

  # Connect to specific device
  gbox device-connect --device abc123xyz456-usb

  # Connect device in background
  gbox device-connect --device abc789pqr012-ip --background

  # List all available devices
  gbox device-connect ls

  # List devices in JSON format
  gbox device-connect ls --format json

  # Unregister specific device
  gbox device-connect unregister abc789pqr012-ip

  # Stop the device proxy service
  gbox device-connect kill-server

Available Commands:
  kill-server Stop the device proxy service
  ls          List all detectable local Android devices and their registration status
  unregister  Unregister one or all active gbox device connections

Flags:
  -b, --background      Run connection in background
  -d, --device string   Specify the Android device ID to connect to
  -h, --help            help for device-connect

Use "gbox device-connect [command] --help" for more information about a command.
```

```bash
❯ gbox device-connect ls --help
List all detectable local Android devices and their registration status.

Usage:
  gbox device-connect ls [flags]

Aliases:
  ls, list

Examples:
  # List all local Android devices and their registration status (default text format):
  gbox device-connect ls

  # List all local Android devices and their registration status in JSON format:
  gbox device-connect ls --format json

Flags:
      --format string   Specify output format. Options are "text" (default) or "json". (default "text")
  -h, --help            help for ls
```

```bash
❯ gbox device-connect unreg --help
Unregister one or all active gbox device connections.

Usage:
  gbox device-connect unregister [device_id] [flags]

Aliases:
  unregister, unreg

Examples:
  # Unregister device with specific device ID:
  gbox device-connect unregister abc789pqr012-ip

  # Unregister all active device connections:
  gbox device-connect unregister --all

Flags:
  -a, --all    Disconnect all active device connections
  -h, --help   help for unregister
```

```bash
❯ gbox device-connect kill-server --help
Stop the device proxy service running on port 19925.

Usage:
  gbox device-connect kill-server [flags]

Aliases:
  kill-server, kill

Examples:
  # Stop the device proxy service gracefully (PID file only)
  gbox device-connect kill-server

  # Force kill the device proxy service (PID file only)
  gbox device-connect kill-server --force

  # Kill all device proxy processes (port and name detection)
  gbox device-connect kill-server --all

  # Force kill all device proxy processes
  gbox device-connect kill-server --all --force

Flags:
  -a, --all     Kill all device proxy processes (not just PID file)
  -f, --force   Force kill the service process
  -h, --help    help for kill-server
```

@zhlmmc 当前只是代码部分写完，并调试通过了，还需要搞定打包集成。
