### PR TITLE
🐛build fix: daemonize error when building multi platform distribution

### DIFF
--- a/packages/cli/internal/device_connect/daemon.go
+++ b/packages/cli/internal/device_connect/daemon.go
@@ -3,14 +3,8 @@ package device_connect
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
-	"syscall"
-	"time"
-
-	"github.com/babelcloud/gbox/packages/cli/config"
-	"github.com/babelcloud/gbox/packages/cli/internal/profile"
 )
 
 // EnsureDeviceProxyRunning checks if the service is running, and starts it if not
@@ -23,65 +17,6 @@ func EnsureDeviceProxyRunning(isServiceRunning func() (bool, error)) error {
 		return nil
 	}
 	return StartDeviceProxyService()
-}
-
-func StartDeviceProxyService() error {
-	binaryPath, err := FindDeviceProxyBinary()
-	if err != nil {
-		return fmt.Errorf("device proxy binary not found: %v", err)
-	}
-
-	// Create device proxy home directory
-	deviceProxyHome := config.GetDeviceProxyHome()
-	if err := os.MkdirAll(deviceProxyHome, 0755); err != nil {
-		return fmt.Errorf("failed to create device proxy home directory: %v", err)
-	}
-
-	// Create log file
-	logFile := filepath.Join(deviceProxyHome, "device-proxy.log")
-	logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	if err != nil {
-		return fmt.Errorf("failed to create log file: %v", err)
-	}
-	defer logFd.Close()
-
-	// Create PID file path
-	pidFile := filepath.Join(deviceProxyHome, "device-proxy.pid")
-
-	// Get API key from current profile
-	apiKey, err := profile.GetCurrentAPIKey()
-	if err != nil {
-		return fmt.Errorf("failed to get API key: %v", err)
-	}
-
-	// Set up environment variables
-	env := os.Environ()
-	env = append(env, fmt.Sprintf("GBOX_API_KEY=%s", apiKey))
-
-	cmd := exec.Command(binaryPath, "--port", "19925", "--on-demand")
-	cmd.Stdout = logFd
-	cmd.Stderr = logFd
-	cmd.Env = env
-
-	// Set process group to make child process independent
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
-	}
-
-	// Start the process
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start device proxy service: %v", err)
-	}
-
-	// Write PID to file
-	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0644); err != nil {
-		// Try to kill the process if we can't write PID file
-		cmd.Process.Kill()
-		return fmt.Errorf("failed to write PID file: %v", err)
-	}
-
-	time.Sleep(2 * time.Second)
-	return nil
 }
 
 func FindDeviceProxyBinary() (string, error) {

--- a/packages/cli/internal/device_connect/daemon_unix.go
+++ b/packages/cli/internal/device_connect/daemon_unix.go
@@ -1,0 +1,74 @@
+//go:build !windows
+
+package device_connect
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/babelcloud/gbox/packages/cli/config"
+	"github.com/babelcloud/gbox/packages/cli/internal/profile"
+)
+
+func StartDeviceProxyService() error {
+	binaryPath, err := FindDeviceProxyBinary()
+	if err != nil {
+		return fmt.Errorf("device proxy binary not found: %v", err)
+	}
+
+	// Create device proxy home directory
+	deviceProxyHome := config.GetDeviceProxyHome()
+	if err := os.MkdirAll(deviceProxyHome, 0755); err != nil {
+		return fmt.Errorf("failed to create device proxy home directory: %v", err)
+	}
+
+	// Create log file
+	logFile := filepath.Join(deviceProxyHome, "device-proxy.log")
+	logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create log file: %v", err)
+	}
+	defer logFd.Close()
+
+	// Create PID file path
+	pidFile := filepath.Join(deviceProxyHome, "device-proxy.pid")
+
+	// Get API key from current profile
+	apiKey, err := profile.GetCurrentAPIKey()
+	if err != nil {
+		return fmt.Errorf("failed to get API key: %v", err)
+	}
+
+	// Set up environment variables
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("GBOX_API_KEY=%s", apiKey))
+
+	cmd := exec.Command(binaryPath, "--port", "19925", "--on-demand")
+	cmd.Stdout = logFd
+	cmd.Stderr = logFd
+	cmd.Env = env
+
+	// Set process group to make child process independent
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+
+	// Start the process
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start device proxy service: %v", err)
+	}
+
+	// Write PID to file
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0644); err != nil {
+		// Try to kill the process if we can't write PID file
+		cmd.Process.Kill()
+		return fmt.Errorf("failed to write PID file: %v", err)
+	}
+
+	time.Sleep(2 * time.Second)
+	return nil
+}

--- a/packages/cli/internal/device_connect/daemon_windows.go
+++ b/packages/cli/internal/device_connect/daemon_windows.go
@@ -1,0 +1,72 @@
+//go:build windows
+
+package device_connect
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/babelcloud/gbox/packages/cli/config"
+	"github.com/babelcloud/gbox/packages/cli/internal/profile"
+)
+
+func StartDeviceProxyService() error {
+	binaryPath, err := FindDeviceProxyBinary()
+	if err != nil {
+		return fmt.Errorf("device proxy binary not found: %v", err)
+	}
+
+	// Create device proxy home directory
+	deviceProxyHome := config.GetDeviceProxyHome()
+	if err := os.MkdirAll(deviceProxyHome, 0755); err != nil {
+		return fmt.Errorf("failed to create device proxy home directory: %v", err)
+	}
+
+	// Create log file
+	logFile := filepath.Join(deviceProxyHome, "device-proxy.log")
+	logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create log file: %v", err)
+	}
+	defer logFd.Close()
+
+	// Create PID file path
+	pidFile := filepath.Join(deviceProxyHome, "device-proxy.pid")
+
+	// Get API key from current profile
+	apiKey, err := profile.GetCurrentAPIKey()
+	if err != nil {
+		return fmt.Errorf("failed to get API key: %v", err)
+	}
+
+	// Set up environment variables
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("GBOX_API_KEY=%s", apiKey))
+
+	cmd := exec.Command(binaryPath, "--port", "19925", "--on-demand")
+	cmd.Stdout = logFd
+	cmd.Stderr = logFd
+	cmd.Env = env
+
+	// Set process group to make child process independent (Windows doesn't support Setpgid)
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+
+	// Start the process
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start device proxy service: %v", err)
+	}
+
+	// Write PID to file
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0644); err != nil {
+		// Try to kill the process if we can't write PID file
+		cmd.Process.Kill()
+		return fmt.Errorf("failed to write PID file: %v", err)
+	}
+
+	time.Sleep(2 * time.Second)
+	return nil
+}

--- a/packages/cli/internal/port-forward/utils_unix.go
+++ b/packages/cli/internal/port-forward/utils_unix.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package port_forward
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// DaemonizeIfNeeded forks to background if foreground==false and not already daemonized.
+// logPath: if not empty, background process logs to this file.
+// Returns (shouldReturn, err): if shouldReturn==true, caller should return immediately (parent process or error).
+func DaemonizeIfNeeded(foreground bool, logPath string) (bool, error) {
+	if foreground || os.Getenv("GBOX_PORTFORWARD_DAEMON") != "" {
+		return false, nil
+	}
+	// open log file
+	logFile := os.Stdout
+	if logPath != "" {
+		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			return true, fmt.Errorf("Failed to open log file: %v", err)
+		}
+		logFile = f
+		defer f.Close()
+	}
+	attr := &os.ProcAttr{
+		Dir:   "",
+		Env:   append(os.Environ(), "GBOX_PORTFORWARD_DAEMON=1"),
+		Files: []*os.File{os.Stdin, logFile, logFile},
+		Sys:   &syscall.SysProcAttr{Setsid: true},
+	}
+	args := os.Args
+	// Remove -f/--foreground from args if present
+	newArgs := []string{}
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-f" || args[i] == "--foreground" {
+			continue
+		}
+		newArgs = append(newArgs, args[i])
+	}
+	proc, err := os.StartProcess(args[0], newArgs, attr)
+	if err != nil {
+		return true, fmt.Errorf("Failed to daemonize: %v", err)
+	}
+	fmt.Printf("[gbox] Port-forward started in background (pid=%d). Logs: %s\nUse 'gbox port-forward list' to view, 'gbox port-forward kill <pid>' to stop.\n", proc.Pid, logPath)
+	return true, nil
+}

--- a/packages/cli/internal/port-forward/utils_windows.go
+++ b/packages/cli/internal/port-forward/utils_windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package port_forward
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// DaemonizeIfNeeded forks to background if foreground==false and not already daemonized.
+// logPath: if not empty, background process logs to this file.
+// Returns (shouldReturn, err): if shouldReturn==true, caller should return immediately (parent process or error).
+func DaemonizeIfNeeded(foreground bool, logPath string) (bool, error) {
+	if foreground || os.Getenv("GBOX_PORTFORWARD_DAEMON") != "" {
+		return false, nil
+	}
+	// open log file
+	logFile := os.Stdout
+	if logPath != "" {
+		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			return true, fmt.Errorf("Failed to open log file: %v", err)
+		}
+		logFile = f
+		defer f.Close()
+	}
+	attr := &os.ProcAttr{
+		Dir:   "",
+		Env:   append(os.Environ(), "GBOX_PORTFORWARD_DAEMON=1"),
+		Files: []*os.File{os.Stdin, logFile, logFile},
+		Sys:   &syscall.SysProcAttr{},
+	}
+	args := os.Args
+	// Remove -f/--foreground from args if present
+	newArgs := []string{}
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-f" || args[i] == "--foreground" {
+			continue
+		}
+		newArgs = append(newArgs, args[i])
+	}
+	proc, err := os.StartProcess(args[0], newArgs, attr)
+	if err != nil {
+		return true, fmt.Errorf("Failed to daemonize: %v", err)
+	}
+	fmt.Printf("[gbox] Port-forward started in background (pid=%d). Logs: %s\nUse 'gbox port-forward list' to view, 'gbox port-forward kill <pid>' to stop.\n", proc.Pid, logPath)
+	return true, nil
+}


### PR DESCRIPTION
CI 上发现的问题：https://github.com/babelcloud/gbox/actions/runs/16776876244/job/47504940438
本地构建也会：
```bash
➜  gru-sandbox git:(main) make dist VERSION=0.0.21 GBOX_GITHUB_CLIENT_SECRET=3aae0281b600819b31b59539ca207cc8a1763396

Building Go binary for all platforms...
Building binaries for all supported platforms...
Building gbox-linux-amd64...
Building gbox-linux-arm64...
Building gbox-darwin-amd64...
Building gbox-darwin-arm64...
Building gbox-windows-amd64...
# github.com/babelcloud/gbox/packages/cli/internal/port-forward
internal/port-forward/utils.go:247:31: unknown field Setsid in struct literal of type syscall.SysProcAttr
# github.com/babelcloud/gbox/packages/cli/internal/device_connect
internal/device_connect/daemon.go:68:3: unknown field Setpgid in struct literal of type syscall.SysProcAttr
Building gbox-windows-arm64...
# github.com/babelcloud/gbox/packages/cli/internal/port-forward
internal/port-forward/utils.go:247:31: unknown field Setsid in struct literal of type syscall.SysProcAttr
# github.com/babelcloud/gbox/packages/cli/internal/device_connect
internal/device_connect/daemon.go:68:3: unknown field Setpgid in struct literal of type syscall.SysProcAttr
make[1]: *** [binary-all] Error 1
make: *** [build] Error 2
```