### PR TITLE
 fix: brew-core version can't login and use device-connect

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,67 @@ jobs:
             fi
           done
 
+      - name: Create device-proxy public assets
+        run: |
+          # Create device-proxy binaries as public assets for CLI download
+          for platform in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64 windows-amd64 windows-arm64; do
+            echo "Creating device-proxy asset for platform: $platform"
+            
+            # Create temporary directory
+            TEMP_DIR=$(mktemp -d)
+            cd "$TEMP_DIR"
+            
+            # Find the corresponding device-proxy binary from the merged packages
+            if [[ "$platform" == *"windows"* ]]; then
+              MAIN_FILE="../dist/gbox-windows-$(echo $platform | cut -d'-' -f2)-${{ env.VERSION }}.zip"
+              ASSET_NAME="gbox-device-proxy-${platform}.zip"
+            else
+              MAIN_FILE="../dist/gbox-$(echo $platform | cut -d'-' -f1)-$(echo $platform | cut -d'-' -f2)-${{ env.VERSION }}.tar.gz"
+              ASSET_NAME="gbox-device-proxy-${platform}.tar.gz"
+            fi
+            
+            if [ -f "$MAIN_FILE" ]; then
+              # Extract the main package
+              if [[ "$platform" == *"windows"* ]]; then
+                unzip -q "$MAIN_FILE"
+              else
+                tar -xzf "$MAIN_FILE"
+              fi
+              
+              # Find device-proxy binary
+              DEVICE_PROXY_BIN=""
+              if [ -f "bin/gbox-device-proxy" ]; then
+                DEVICE_PROXY_BIN="bin/gbox-device-proxy"
+              elif [ -f "bin/gbox-device-proxy.exe" ]; then
+                DEVICE_PROXY_BIN="bin/gbox-device-proxy.exe"
+              fi
+              
+              if [ -n "$DEVICE_PROXY_BIN" ]; then
+                # Create device-proxy package
+                if [[ "$platform" == *"windows"* ]]; then
+                  zip -j "$ASSET_NAME" "$DEVICE_PROXY_BIN"
+                else
+                  tar -czf "$ASSET_NAME" "$DEVICE_PROXY_BIN"
+                fi
+                
+                # Move to dist directory and generate SHA256
+                mv "$ASSET_NAME" "../dist/"
+                cd "../dist"
+                sha256sum "$ASSET_NAME" > "$ASSET_NAME.sha256"
+                cd "$TEMP_DIR"
+                
+                echo "Created device-proxy asset: $ASSET_NAME"
+              else
+                echo "Warning: device-proxy binary not found in $MAIN_FILE"
+              fi
+            else
+              echo "Warning: Main file $MAIN_FILE not found for platform $platform"
+            fi
+            
+            cd ..
+            rm -rf "$TEMP_DIR"
+          done
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -177,7 +238,10 @@ jobs:
             dist/gbox-*.tar.gz.sha256
             dist/gbox-*.zip
             dist/gbox-*.zip.sha256
-            !dist/gbox-device-proxy-*
+            dist/gbox-device-proxy-*.tar.gz
+            dist/gbox-device-proxy-*.tar.gz.sha256
+            dist/gbox-device-proxy-*.zip
+            dist/gbox-device-proxy-*.zip.sha256
           draft: true
           prerelease: false
           generate_release_notes: true

--- a/packages/cli/cmd/login.go
+++ b/packages/cli/cmd/login.go
@@ -124,13 +124,20 @@ var loginCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
+		// Check if GitHub client secret is available
+		hasClientSecret := config.GetGithubClientSecret() != ""
+
 		// Check if user has browser environment
 		hasBrowser := checkBrowserEnvironment()
 
 		var accessToken string
 		var err error
 
-		if hasBrowser {
+		// Force Device Flow if no client secret is available (for reproducible builds)
+		if !hasClientSecret {
+			fmt.Println("GitHub client secret not available. Using device authorization flow for reproducible builds...")
+			accessToken, err = authenticateWithDevice(ctx)
+		} else if hasBrowser {
 			fmt.Println("Browser environment detected. Using OAuth authorization code flow...")
 			accessToken, err = authenticateWithBrowser(ctx)
 		} else {


### PR DESCRIPTION
背景：gbox cli 的构建过程需要把 密钥（登陆过程） 和 token（二次下载 device conect 二进制）打入可执行文件中，目前 CI 上通过配置环境变量实现了；但 homebrew core 要求完全可重现的从源码构建（会在 GitHub Actions 上用它自己的 CI 环境（Linux / macOS）拉取源码，然后完全从零构建），其构建环境不支持配置私密环境变量。导致 brew-core 版本 login 和 device-connect 无法正常使用。
目前的解法是：登录在无 secret 时强制 Device Flow；device-proxy 优先从 gbox 公共 Release 下载；Release workflow 会上传 gbox-device-proxy-* 公开资产。