### PR TITLE
fix: auto update device proxy

### DIFF
--- a/packages/cli/internal/device_connect/daemon.go
+++ b/packages/cli/internal/device_connect/daemon.go
@@ -1,7 +1,10 @@
 package device_connect
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,6 +30,136 @@ func isExecutableFile(path string) bool {
 	// Check if it has execute permissions
 	mode := info.Mode()
 	return mode&0111 != 0 // Check if any execute bit is set
+}
+
+// calculateSHA256 calculates the SHA256 hash of a file
+func calculateSHA256(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %v", err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", fmt.Errorf("failed to read file: %v", err)
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+
+// checkRemoteVersionAndCompare checks if remote version is different from local
+func checkRemoteVersionAndCompare(localBinaryPath string) (bool, error) {
+	fmt.Println("检查远程版本并比对SHA256...")
+	
+	// Get the asset name for current platform
+	assetName := getAssetNameForPlatform()
+	deviceProxyHome := config.GetDeviceProxyHome()
+	localArchivePath := filepath.Join(deviceProxyHome, assetName)
+	
+	// Check if both local files exist
+	if _, err := os.Stat(localArchivePath); err != nil {
+		fmt.Println("本地压缩包不存在，需要下载")
+		return true, nil
+	}
+	
+	if _, err := os.Stat(localBinaryPath); err != nil {
+		fmt.Println("本地二进制文件不存在，需要下载")
+		return true, nil
+	}
+	
+	// Both files exist, check SHA256
+	fmt.Println("本地文件已存在，开始校验SHA256...")
+	
+	// Get GitHub token
+	token := config.GetGithubToken()
+	
+	// Try to get latest release from public repository first
+	release, err := getLatestRelease(deviceProxyPublicRepo, "")
+	if err != nil {
+		fmt.Printf("从公共仓库获取最新版本失败: %v，尝试私有仓库\n", err)
+		if token != "" {
+			release, err = getLatestRelease(deviceProxyRepo, token)
+			if err != nil {
+				return false, fmt.Errorf("从私有仓库获取最新版本也失败: %v", err)
+			}
+		} else {
+			return false, fmt.Errorf("无法获取远程版本信息: %v", err)
+		}
+	}
+	
+	// Find device-proxy asset for current platform
+	assetURL, _, err := findDeviceProxyAssetForPlatform(release, token)
+	if err != nil {
+		return false, fmt.Errorf("找不到平台对应的资源: %v", err)
+	}
+	
+	// Try to get remote SHA256 from SHA256 file first (more efficient)
+	fmt.Println("尝试从SHA256文件获取远程压缩包哈希值...")
+	remoteSHA256, err := getRemoteSHA256FromFile(release, assetName, token)
+	if err != nil {
+		fmt.Printf("无法从SHA256文件获取哈希值: %v，回退到下载压缩包方式\n", err)
+		// Fallback to downloading the archive for SHA256 calculation
+		remoteSHA256, err = getRemoteSHA256FromArchive(assetURL, assetName, token)
+		if err != nil {
+			return false, fmt.Errorf("获取远程压缩包SHA256失败: %v", err)
+		}
+	} else {
+		fmt.Printf("成功从SHA256文件获取远程压缩包SHA256: %s\n", remoteSHA256)
+	}
+	
+	// Calculate local archive SHA256
+	localSHA256, err := calculateSHA256(localArchivePath)
+	if err != nil {
+		return false, fmt.Errorf("计算本地压缩包SHA256失败: %v", err)
+	}
+	fmt.Printf("本地压缩包SHA256: %s\n", localSHA256)
+	
+	// Compare SHA256
+	if remoteSHA256 == localSHA256 {
+		fmt.Println("SHA256校验通过，本地版本是最新的")
+		return false, nil
+	} else {
+		fmt.Println("SHA256校验失败，远程版本已更新")
+		return true, nil
+	}
+}
+
+// getRemoteSHA256FromFile gets the remote SHA256 hash from the SHA256 file
+func getRemoteSHA256FromFile(release *GitHubRelease, assetName, token string) (string, error) {
+	sha256URL, err := findSHA256File(release, assetName)
+	if err != nil {
+		return "", err
+	}
+	
+	return downloadSHA256File(sha256URL, token)
+}
+
+// getRemoteSHA256FromArchive downloads the remote archive to get its SHA256 (fallback method)
+func getRemoteSHA256FromArchive(assetURL, assetName, token string) (string, error) {
+	// Download remote archive to temp to get SHA256
+	tempDir, err := os.MkdirTemp("", "gbox-device-proxy-temp-*")
+	if err != nil {
+		return "", fmt.Errorf("创建临时目录失败: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+	
+	tempArchivePath := filepath.Join(tempDir, assetName)
+	fmt.Printf("下载远程压缩包到临时位置进行SHA256校验: %s\n", tempArchivePath)
+	
+	if err := downloadFile(assetURL, tempArchivePath, token); err != nil {
+		return "", fmt.Errorf("下载远程压缩包失败: %v", err)
+	}
+	
+	// Calculate remote archive SHA256
+	remoteSHA256, err := calculateSHA256(tempArchivePath)
+	if err != nil {
+		return "", fmt.Errorf("计算远程压缩包SHA256失败: %v", err)
+	}
+	fmt.Printf("远程压缩包SHA256: %s\n", remoteSHA256)
+	
+	return remoteSHA256, nil
 }
 
 // EnsureDeviceProxyRunning checks if the service is running, and starts it if not
@@ -102,7 +235,32 @@ func FindDeviceProxyBinary() (string, error) {
 		if debug {
 			fmt.Fprintf(os.Stderr, "[DEBUG] Found gbox-device-proxy binary in device proxy home: %s\n", deviceProxyBinaryPath)
 		}
-		return deviceProxyBinaryPath, nil
+		
+		// Check if remote version is different
+		needUpdate, err := checkRemoteVersionAndCompare(deviceProxyBinaryPath)
+		if err != nil {
+			fmt.Printf("检查远程版本失败: %v，使用本地版本\n", err)
+			return deviceProxyBinaryPath, nil
+		}
+		
+		if needUpdate {
+			fmt.Println("检测到远程版本更新，删除本地文件并重新下载")
+			
+			// Remove local files
+			assetName := getAssetNameForPlatform()
+			localArchivePath := filepath.Join(deviceProxyHome, assetName)
+			
+			if _, err := os.Stat(localArchivePath); err == nil {
+				if err := os.Remove(localArchivePath); err != nil {
+					fmt.Printf("警告: 删除本地压缩包失败: %v\n", err)
+				}
+			}
+			if err := os.Remove(deviceProxyBinaryPath); err != nil {
+				fmt.Printf("警告: 删除本地二进制文件失败: %v\n", err)
+			}
+		} else {
+			return deviceProxyBinaryPath, nil
+		}
 	}
 
 	// Priority 4: Check PATH
@@ -162,6 +320,36 @@ func FindDeviceProxyBinary() (string, error) {
 	}
 
 	return downloadedPath, nil
+}
+
+// getAssetNameForPlatform returns the asset name for current platform
+func getAssetNameForPlatform() string {
+	osName := runtime.GOOS
+	arch := runtime.GOARCH
+
+	var platform string
+	switch osName {
+	case "darwin":
+		if arch == "amd64" {
+			platform = "darwin-amd64"
+		} else if arch == "arm64" {
+			platform = "darwin-arm64"
+		}
+	case "linux":
+		if arch == "amd64" {
+			platform = "linux-amd64"
+		} else if arch == "arm64" {
+			platform = "linux-arm64"
+		}
+	case "windows":
+		if arch == "amd64" {
+			platform = "windows-amd64"
+		} else if arch == "arm64" {
+			platform = "windows-arm64"
+		}
+	}
+
+	return fmt.Sprintf("gbox-device-proxy-%s.tar.gz", platform)
 }
 
 func FindBabelUmbrellaDir(startDir string) string {


### PR DESCRIPTION
Added the function of automatically installing the new version when calling device-connect
1. Run device-connect to check if the binary is available locally. If not, install it.
2. If it is available locally, pull the corresponding SHA256 file from GitHub and use the SHA256 to determine if the local version is the latest.
3. If the local version is the latest, skip the download. If not, delete the old version and download the latest one.