### PR TITLE
:rotating_light: refactor: remove GitHub token handling for security

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 # Build Variables
 # ==============================================================================
 export GBOX_GITHUB_CLIENT_SECRET
-export GITHUB_TOKEN
 MODULE_PREFIX := github.com/babelcloud/gbox
 
 # Check if .git directory exists to determine version from git
@@ -20,8 +19,7 @@ BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown
 LDFLAGS := -ldflags "-s -w -X '$(MODULE_PREFIX)/packages/cli/internal/version.Version=$(VERSION)' \
                      -X '$(MODULE_PREFIX)/packages/cli/internal/version.BuildTime=$(BUILD_TIME)' \
                      -X '$(MODULE_PREFIX)/packages/cli/internal/version.CommitID=$(COMMIT_ID)' \
-                     -X '$(MODULE_PREFIX)/packages/cli/config.githubClientSecret=$(GBOX_GITHUB_CLIENT_SECRET)' \
-                                                   -X '$(MODULE_PREFIX)/packages/cli/config.githubToken=$(GITHUB_TOKEN)'"
+                     -X '$(MODULE_PREFIX)/packages/cli/config.githubClientSecret=$(GBOX_GITHUB_CLIENT_SECRET)' 
 # ==============================================================================
 
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown
 LDFLAGS := -ldflags "-s -w -X '$(MODULE_PREFIX)/packages/cli/internal/version.Version=$(VERSION)' \
                      -X '$(MODULE_PREFIX)/packages/cli/internal/version.BuildTime=$(BUILD_TIME)' \
                      -X '$(MODULE_PREFIX)/packages/cli/internal/version.CommitID=$(COMMIT_ID)' \
-                     -X '$(MODULE_PREFIX)/packages/cli/config.githubClientSecret=$(GBOX_GITHUB_CLIENT_SECRET)' 
+                     -X '$(MODULE_PREFIX)/packages/cli/config.githubClientSecret=$(GBOX_GITHUB_CLIENT_SECRET)'"
 # ==============================================================================
 
 

--- a/packages/cli/Makefile
+++ b/packages/cli/Makefile
@@ -19,8 +19,7 @@ GOARCH ?= $(shell go env GOARCH)
 LDFLAGS := -ldflags "-X $(MODULE_PREFIX)/packages/cli/internal/version.Version=$(VERSION) \
                      -X $(MODULE_PREFIX)/packages/cli/internal/version.BuildTime=$(BUILD_TIME) \
                      -X $(MODULE_PREFIX)/packages/cli/internal/version.CommitID=$(COMMIT_ID) \
-					 -X $(MODULE_PREFIX)/packages/cli/config.githubClientSecret=$(GBOX_GITHUB_CLIENT_SECRET) \
-					 -X $(MODULE_PREFIX)/packages/cli/config.githubToken=$(GITHUB_TOKEN)"
+					 -X $(MODULE_PREFIX)/packages/cli/config.githubClientSecret=$(GBOX_GITHUB_CLIENT_SECRET) 
 
 # Supported platforms
 PLATFORMS := linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 windows-amd64 windows-arm64

--- a/packages/cli/Makefile
+++ b/packages/cli/Makefile
@@ -88,7 +88,7 @@ run: ## Run the application with PROJECT_ROOT environment variable (Usage: make 
 	go run main.go $(filter-out $@,$(MAKECMDGOALS))
 
 test: ## Run tests
-	go test ./cmd -v
+	go test ./... -v
 
 # Build binaries for all supported platforms
 binary-all: ## Build binaries for all supported platforms

--- a/packages/cli/Makefile
+++ b/packages/cli/Makefile
@@ -19,7 +19,7 @@ GOARCH ?= $(shell go env GOARCH)
 LDFLAGS := -ldflags "-X $(MODULE_PREFIX)/packages/cli/internal/version.Version=$(VERSION) \
                      -X $(MODULE_PREFIX)/packages/cli/internal/version.BuildTime=$(BUILD_TIME) \
                      -X $(MODULE_PREFIX)/packages/cli/internal/version.CommitID=$(COMMIT_ID) \
-					 -X $(MODULE_PREFIX)/packages/cli/config.githubClientSecret=$(GBOX_GITHUB_CLIENT_SECRET) 
+					 -X $(MODULE_PREFIX)/packages/cli/config.githubClientSecret=$(GBOX_GITHUB_CLIENT_SECRET)"
 
 # Supported platforms
 PLATFORMS := linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 windows-amd64 windows-arm64

--- a/packages/cli/config/config.go
+++ b/packages/cli/config/config.go
@@ -32,7 +32,6 @@ func init() {
 	v.SetDefault("profile.path", "")
 
 	v.SetDefault("github.client_secret", "")
-	v.SetDefault("github.token", "")
 
 	// Environment variables
 	v.AutomaticEnv()

--- a/packages/cli/config/config.go
+++ b/packages/cli/config/config.go
@@ -13,7 +13,6 @@ var v *viper.Viper
 
 var (
 	githubClientSecret string
-	githubToken        string
 )
 
 func init() {
@@ -44,7 +43,6 @@ func init() {
 	v.BindEnv("device_proxy.home", "DEVICE_PROXY_HOME")
 	v.BindEnv("profile.path", "GBOX_PROFILE_PATH") // Bind profile path env var
 	v.BindEnv("github.client_secret", "GBOX_GITHUB_CLIENT_SECRET")
-	v.BindEnv("github.token", "GITHUB_TOKEN")
 
 	// Config file
 	v.SetConfigName("config")
@@ -118,14 +116,6 @@ func GetGithubClientSecret() string {
 		return githubClientSecret
 	}
 	return v.GetString("github.client_secret")
-}
-
-// GetGithubToken returns the GitHub token from env or config
-func GetGithubToken() string {
-	if githubToken != "" {
-		return githubToken
-	}
-	return v.GetString("github.token")
 }
 
 // GetGboxHome returns the gbox home directory

--- a/packages/cli/internal/device_connect/daemon.go
+++ b/packages/cli/internal/device_connect/daemon.go
@@ -1,10 +1,7 @@
 package device_connect
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,22 +27,6 @@ func isExecutableFile(path string) bool {
 	// Check if it has execute permissions
 	mode := info.Mode()
 	return mode&0111 != 0 // Check if any execute bit is set
-}
-
-// calculateSHA256 calculates the SHA256 hash of a file
-func calculateSHA256(filePath string) (string, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to open file: %v", err)
-	}
-	defer file.Close()
-
-	hash := sha256.New()
-	if _, err := io.Copy(hash, file); err != nil {
-		return "", fmt.Errorf("failed to read file: %v", err)
-	}
-
-	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 // EnsureDeviceProxyRunning checks if the service is running, and starts it if not

--- a/packages/cli/internal/device_connect/daemon.go
+++ b/packages/cli/internal/device_connect/daemon.go
@@ -48,111 +48,6 @@ func calculateSHA256(filePath string) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-
-// checkRemoteVersionAndCompare checks if remote version is different from local
-func checkRemoteVersionAndCompare(localBinaryPath string, debug bool) (bool, error) {
-	// Get the asset name for current platform
-	assetName := getAssetNameForPlatform()
-	deviceProxyHome := config.GetDeviceProxyHome()
-	localArchivePath := filepath.Join(deviceProxyHome, assetName)
-	
-	// Check if both local files exist
-	if _, err := os.Stat(localArchivePath); err != nil {
-		return true, nil
-	}
-	
-	if _, err := os.Stat(localBinaryPath); err != nil {
-		return true, nil
-	}
-	
-	// Both files exist, check SHA256
-	
-	// Get GitHub token
-	token := config.GetGithubToken()
-	
-	// Try to get latest release from public repository first
-	release, err := getLatestRelease(deviceProxyPublicRepo, "")
-	if err != nil {
-		if debug {
-			fmt.Printf("Failed to get latest version from public repository: %v, trying private repository\n", err)
-		}
-		if token != "" {
-			release, err = getLatestRelease(deviceProxyRepo, token)
-			if err != nil {
-				return false, fmt.Errorf("Failed to get latest version from private repository: %v", err)
-			}
-		} else {
-			return false, fmt.Errorf("Unable to get remote version information: %v", err)
-		}
-	}
-	
-	// Find device-proxy asset for current platform
-	assetURL, _, err := findDeviceProxyAssetForPlatform(release, token)
-	if err != nil {
-		return false, fmt.Errorf("Cannot find platform-specific asset: %v", err)
-	}
-	
-	// Try to get remote SHA256 from SHA256 file first (more efficient)
-	remoteSHA256, err := getRemoteSHA256FromFile(release, assetName, token)
-	if err != nil {
-		if debug {
-			fmt.Printf("Cannot get hash from SHA256 file: %v, falling back to downloading archive\n", err)
-		}
-		// Fallback to downloading the archive for SHA256 calculation
-		remoteSHA256, err = getRemoteSHA256FromArchive(assetURL, assetName, token)
-		if err != nil {
-			return false, fmt.Errorf("Failed to get remote archive SHA256: %v", err)
-		}
-	}
-	
-	// Calculate local archive SHA256
-	localSHA256, err := calculateSHA256(localArchivePath)
-	if err != nil {
-		return false, fmt.Errorf("Failed to calculate local archive SHA256: %v", err)
-	}
-	
-	// Compare SHA256
-	if remoteSHA256 == localSHA256 {
-		return false, nil
-	} else {
-		return true, nil
-	}
-}
-
-// getRemoteSHA256FromFile gets the remote SHA256 hash from the SHA256 file
-func getRemoteSHA256FromFile(release *GitHubRelease, assetName, token string) (string, error) {
-	sha256URL, err := findSHA256File(release, assetName)
-	if err != nil {
-		return "", err
-	}
-	
-	return downloadSHA256File(sha256URL, token)
-}
-
-// getRemoteSHA256FromArchive downloads the remote archive to get its SHA256 (fallback method)
-func getRemoteSHA256FromArchive(assetURL, assetName, token string) (string, error) {
-	// Download remote archive to temp to get SHA256
-	tempDir, err := os.MkdirTemp("", "gbox-device-proxy-temp-*")
-	if err != nil {
-		return "", fmt.Errorf("Failed to create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-	
-	tempArchivePath := filepath.Join(tempDir, assetName)
-	
-	if err := downloadFile(assetURL, tempArchivePath, token); err != nil {
-		return "", fmt.Errorf("Failed to download remote archive: %v", err)
-	}
-	
-	// Calculate remote archive SHA256
-	remoteSHA256, err := calculateSHA256(tempArchivePath)
-	if err != nil {
-		return "", fmt.Errorf("Failed to calculate remote archive SHA256: %v", err)
-	}
-	
-	return remoteSHA256, nil
-}
-
 // EnsureDeviceProxyRunning checks if the service is running, and starts it if not
 func EnsureDeviceProxyRunning(isServiceRunning func() (bool, error)) error {
 	running, err := isServiceRunning()
@@ -226,33 +121,19 @@ func FindDeviceProxyBinary() (string, error) {
 		if debug {
 			fmt.Fprintf(os.Stderr, "[DEBUG] Found gbox-device-proxy binary in device proxy home: %s\n", deviceProxyBinaryPath)
 		}
-		
-		// Check if remote version is different
-		needUpdate, err := checkRemoteVersionAndCompare(deviceProxyBinaryPath, debug)
+
+		// Use the new version-aware download function
+		// This will check if we need to update and download if necessary
+		binaryPath, err := CheckAndDownloadDeviceProxy()
 		if err != nil {
+			if debug {
+				fmt.Printf("Warning: Failed to check/download device proxy: %v\n", err)
+			}
+			// Return existing binary if download fails
 			return deviceProxyBinaryPath, nil
 		}
-		
-		if needUpdate {			
-			// Remove local files
-			assetName := getAssetNameForPlatform()
-			localArchivePath := filepath.Join(deviceProxyHome, assetName)
-			
-			if _, err := os.Stat(localArchivePath); err == nil {
-				if err := os.Remove(localArchivePath); err != nil {
-					if debug {
-						fmt.Printf("Warning: Failed to remove local archive: %v\n", err)
-					}
-				}
-			}
-			if err := os.Remove(deviceProxyBinaryPath); err != nil {
-				if debug {
-					fmt.Printf("Warning: Failed to remove local binary file: %v\n", err)
-				}
-			}
-		} else {
-			return deviceProxyBinaryPath, nil
-		}
+
+		return binaryPath, nil
 	}
 
 	// Priority 4: Check PATH
@@ -312,36 +193,6 @@ func FindDeviceProxyBinary() (string, error) {
 	}
 
 	return downloadedPath, nil
-}
-
-// getAssetNameForPlatform returns the asset name for current platform
-func getAssetNameForPlatform() string {
-	osName := runtime.GOOS
-	arch := runtime.GOARCH
-
-	var platform string
-	switch osName {
-	case "darwin":
-		if arch == "amd64" {
-			platform = "darwin-amd64"
-		} else if arch == "arm64" {
-			platform = "darwin-arm64"
-		}
-	case "linux":
-		if arch == "amd64" {
-			platform = "linux-amd64"
-		} else if arch == "arm64" {
-			platform = "linux-arm64"
-		}
-	case "windows":
-		if arch == "amd64" {
-			platform = "windows-amd64"
-		} else if arch == "arm64" {
-			platform = "windows-arm64"
-		}
-	}
-
-	return fmt.Sprintf("gbox-device-proxy-%s.tar.gz", platform)
 }
 
 func FindBabelUmbrellaDir(startDir string) string {

--- a/packages/cli/internal/device_connect/daemon_test.go
+++ b/packages/cli/internal/device_connect/daemon_test.go
@@ -1,0 +1,141 @@
+package device_connect
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestIsExecutableFile(t *testing.T) {
+	// Test with a non-existent file
+	if isExecutableFile("/non/existent/file") {
+		t.Error("Non-existent file should not be considered executable")
+	}
+
+	// Test with a directory
+	tempDir, err := os.MkdirTemp("", "gbox-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	if isExecutableFile(tempDir) {
+		t.Error("Directory should not be considered executable")
+	}
+
+	// Test with a regular file
+	tempFile := filepath.Join(tempDir, "test.txt")
+	if err := os.WriteFile(tempFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	if isExecutableFile(tempFile) {
+		t.Error("Regular file should not be considered executable")
+	}
+
+	// Test with an executable file (on Unix systems)
+	if runtime.GOOS != "windows" {
+		execFile := filepath.Join(tempDir, "test.sh")
+		if err := os.WriteFile(execFile, []byte("#!/bin/sh\necho test"), 0755); err != nil {
+			t.Fatalf("Failed to create executable file: %v", err)
+		}
+
+		if !isExecutableFile(execFile) {
+			t.Error("Executable file should be considered executable")
+		}
+	}
+}
+
+func TestCalculateSHA256(t *testing.T) {
+	// Create a temporary file with known content
+	tempDir, err := os.MkdirTemp("", "gbox-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	testFile := filepath.Join(tempDir, "test.txt")
+	testContent := "Hello, World!"
+	if err := os.WriteFile(testFile, []byte(testContent), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Calculate SHA256
+	hash, err := calculateSHA256(testFile)
+	if err != nil {
+		t.Fatalf("Failed to calculate SHA256: %v", err)
+	}
+
+	if len(hash) != 64 {
+		t.Errorf("Expected SHA256 hash to be 64 characters, got %d: %s", len(hash), hash)
+	}
+
+	// Verify it's a valid hex string
+	for _, char := range hash {
+		if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f')) {
+			t.Errorf("SHA256 hash should only contain hex characters, got: %c", char)
+		}
+	}
+
+	t.Logf("SHA256 hash: %s", hash)
+}
+
+func TestFindBabelUmbrellaDir(t *testing.T) {
+	// Test with current directory (should not find babel-umbrella)
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current directory: %v", err)
+	}
+
+	result := FindBabelUmbrellaDir(currentDir)
+
+	// In the test environment, we might not have babel-umbrella
+	// So we just test that the function doesn't crash
+	if result != "" {
+		t.Logf("Found babel-umbrella directory: %s", result)
+	} else {
+		t.Log("No babel-umbrella directory found (expected in test environment)")
+	}
+}
+
+func TestSetupDeviceProxyEnvironment(t *testing.T) {
+	apiKey := "test-api-key-12345"
+	env := setupDeviceProxyEnvironment(apiKey)
+
+	// Check that required environment variables are set
+	found := false
+	for _, envVar := range env {
+		if contains(envVar, "GBOX_API_KEY="+apiKey) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected GBOX_API_KEY to be set in environment")
+	}
+
+	found = false
+	for _, envVar := range env {
+		if contains(envVar, "GBOX_PROVIDER_TYPE=org") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected GBOX_PROVIDER_TYPE to be set in environment")
+	}
+
+	found = false
+	for _, envVar := range env {
+		if contains(envVar, "ANDROID_DEVMGR_ENDPOINT=") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected ANDROID_DEVMGR_ENDPOINT to be set in environment")
+	}
+
+	t.Logf("Environment variables set: %d", len(env))
+}

--- a/packages/cli/internal/device_connect/daemon_test.go
+++ b/packages/cli/internal/device_connect/daemon_test.go
@@ -47,40 +47,6 @@ func TestIsExecutableFile(t *testing.T) {
 	}
 }
 
-func TestCalculateSHA256(t *testing.T) {
-	// Create a temporary file with known content
-	tempDir, err := os.MkdirTemp("", "gbox-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	testFile := filepath.Join(tempDir, "test.txt")
-	testContent := "Hello, World!"
-	if err := os.WriteFile(testFile, []byte(testContent), 0644); err != nil {
-		t.Fatalf("Failed to create test file: %v", err)
-	}
-
-	// Calculate SHA256
-	hash, err := calculateSHA256(testFile)
-	if err != nil {
-		t.Fatalf("Failed to calculate SHA256: %v", err)
-	}
-
-	if len(hash) != 64 {
-		t.Errorf("Expected SHA256 hash to be 64 characters, got %d: %s", len(hash), hash)
-	}
-
-	// Verify it's a valid hex string
-	for _, char := range hash {
-		if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f')) {
-			t.Errorf("SHA256 hash should only contain hex characters, got: %c", char)
-		}
-	}
-
-	t.Logf("SHA256 hash: %s", hash)
-}
-
 func TestFindBabelUmbrellaDir(t *testing.T) {
 	// Test with current directory (should not find babel-umbrella)
 	currentDir, err := os.Getwd()

--- a/packages/cli/internal/device_connect/downloader.go
+++ b/packages/cli/internal/device_connect/downloader.go
@@ -34,63 +34,6 @@ type GitHubRelease struct {
 	} `json:"assets"`
 }
 
-// findSHA256File finds the SHA256 file for a given asset
-func findSHA256File(release *GitHubRelease, assetName string) (string, error) {
-	sha256FileName := assetName + ".sha256"
-
-	for _, asset := range release.Assets {
-		if asset.Name == sha256FileName {
-			if asset.DownloadURL != "" {
-				return asset.DownloadURL, nil
-			}
-			if asset.URL != "" {
-				return asset.URL, nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("SHA256 file not found for asset: %s", assetName)
-}
-
-// downloadSHA256File downloads and returns the SHA256 hash from a SHA256 file
-func downloadSHA256File(sha256URL string) (string, error) {
-	req, err := http.NewRequest("GET", sha256URL, nil)
-	if err != nil {
-		return "", err
-	}
-
-	req.Header.Set("Accept", "text/plain")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to download SHA256 file, status: %d", resp.StatusCode)
-	}
-
-	// Read the SHA256 hash from the file
-	sha256Bytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read SHA256 file: %v", err)
-	}
-
-	// Extract the hash (format: "hash filename")
-	sha256Line := strings.TrimSpace(string(sha256Bytes))
-	parts := strings.Fields(sha256Line)
-	if len(parts) < 1 {
-		return "", fmt.Errorf("invalid SHA256 file format: %s", sha256Line)
-	}
-
-	return parts[0], nil
-}
-
 // VersionInfo represents version information
 type VersionInfo struct {
 	TagName    string `json:"tag_name"`

--- a/packages/cli/internal/device_connect/downloader.go
+++ b/packages/cli/internal/device_connect/downloader.go
@@ -95,8 +95,6 @@ func downloadSHA256File(sha256URL, token string) (string, error) {
 
 // DownloadDeviceProxy downloads the latest gbox-device-proxy binary from GitHub
 func DownloadDeviceProxy() (string, error) {
-	// Get GitHub token - try both sources
-	token := config.GetGithubToken()
 
 	// Try to download from public repository first (no token required)
 	release, err := getLatestRelease(deviceProxyPublicRepo, "")
@@ -111,28 +109,7 @@ func DownloadDeviceProxy() (string, error) {
 		}
 	}
 
-	// If public repository fails and we have a token, try private repository
-	if token != "" {
-		fmt.Println("Trying private repository with authentication...")
-		release, err = getLatestRelease(deviceProxyRepo, token)
-		if err != nil {
-			return "", fmt.Errorf("failed to get latest release from private repository: %v", err)
-		}
-
-		assetURL, assetName, err := findDeviceProxyAssetForPlatform(release, token)
-		if err != nil {
-			return "", fmt.Errorf("failed to find asset for platform in private repository: %v", err)
-		}
-
-		binaryPath, err := downloadAndExtractBinaryWithRetry(assetURL, assetName, token)
-		if err != nil {
-			return "", fmt.Errorf("failed to download from private repository: %v", err)
-		}
-
-		return binaryPath, nil
-	}
-
-	return "", fmt.Errorf("failed to download device-proxy: public repository unavailable and no authentication token provided")
+	return "", fmt.Errorf("failed to download device proxy binary")
 }
 
 // getLatestRelease fetches the latest release from GitHub

--- a/packages/cli/internal/device_connect/downloader.go
+++ b/packages/cli/internal/device_connect/downloader.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/babelcloud/gbox/packages/cli/config"
+	"github.com/babelcloud/gbox/packages/cli/internal/version"
 )
 
 const (
@@ -36,7 +37,7 @@ type GitHubRelease struct {
 // findSHA256File finds the SHA256 file for a given asset
 func findSHA256File(release *GitHubRelease, assetName string) (string, error) {
 	sha256FileName := assetName + ".sha256"
-	
+
 	for _, asset := range release.Assets {
 		if asset.Name == sha256FileName {
 			if asset.DownloadURL != "" {
@@ -47,20 +48,17 @@ func findSHA256File(release *GitHubRelease, assetName string) (string, error) {
 			}
 		}
 	}
-	
+
 	return "", fmt.Errorf("SHA256 file not found for asset: %s", assetName)
 }
 
 // downloadSHA256File downloads and returns the SHA256 hash from a SHA256 file
-func downloadSHA256File(sha256URL, token string) (string, error) {
+func downloadSHA256File(sha256URL string) (string, error) {
 	req, err := http.NewRequest("GET", sha256URL, nil)
 	if err != nil {
 		return "", err
 	}
 
-	if token != "" {
-		req.Header.Set("Authorization", "token "+token)
-	}
 	req.Header.Set("Accept", "text/plain")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
@@ -93,27 +91,198 @@ func downloadSHA256File(sha256URL, token string) (string, error) {
 	return parts[0], nil
 }
 
-// DownloadDeviceProxy downloads the latest gbox-device-proxy binary from GitHub
-func DownloadDeviceProxy() (string, error) {
+// VersionInfo represents version information
+type VersionInfo struct {
+	TagName    string `json:"tag_name"`
+	CommitID   string `json:"commit_id"`
+	Downloaded string `json:"downloaded"`
+}
 
-	// Try to download from public repository first (no token required)
-	release, err := getLatestRelease(deviceProxyPublicRepo, "")
-	if err == nil {
-		assetURL, assetName, err := findDeviceProxyAssetForPlatform(release, "")
+// getVersionCachePath returns the path to the version cache file
+func getVersionCachePath() string {
+	deviceProxyHome := config.GetDeviceProxyHome()
+	return filepath.Join(deviceProxyHome, "version.json")
+}
+
+// loadVersionInfo loads version information from cache
+func loadVersionInfo() (*VersionInfo, error) {
+	cachePath := getVersionCachePath()
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var info VersionInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+// saveVersionInfo saves version information to cache
+func saveVersionInfo(info *VersionInfo) error {
+	cachePath := getVersionCachePath()
+	deviceProxyHome := config.GetDeviceProxyHome()
+
+	// Ensure directory exists
+	if err := os.MkdirAll(deviceProxyHome, 0755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(cachePath, data, 0644)
+}
+
+// CheckAndDownloadDeviceProxy checks if update is needed and downloads if necessary
+func CheckAndDownloadDeviceProxy() (string, error) {
+	deviceProxyHome := config.GetDeviceProxyHome()
+	binaryName := "gbox-device-proxy"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binaryPath := filepath.Join(deviceProxyHome, binaryName)
+
+	// Check if binary exists
+	if _, err := os.Stat(binaryPath); err != nil {
+		// Binary doesn't exist, download it
+		return DownloadDeviceProxy()
+	}
+
+	// Load cached version info
+	cachedInfo, err := loadVersionInfo()
+	if err != nil {
+		// No cache, download latest
+		return DownloadDeviceProxy()
+	}
+
+	// Try to find release matching current version first
+	currentVersion := version.ClientInfo()["Version"]
+	currentCommit := version.ClientInfo()["GitCommit"]
+
+	// First try to find exact version match
+	if currentVersion != "dev" {
+		release, err := getReleaseByTag(deviceProxyPublicRepo, currentVersion)
 		if err == nil {
-			binaryPath, err := downloadAndExtractBinaryWithRetry(assetURL, assetName, "")
+			assetURL, assetName, err := findDeviceProxyAssetForPlatform(release)
 			if err == nil {
-				return binaryPath, nil
+				// Found matching version, check if we need to download
+				if cachedInfo.TagName == currentVersion {
+					// Same version, return existing binary
+					return binaryPath, nil
+				}
+				// Different version, download
+				binaryPath, err := downloadAndExtractBinaryWithRetry(assetURL, assetName)
+				if err == nil {
+					// Save version info
+					saveVersionInfo(&VersionInfo{
+						TagName:    currentVersion,
+						CommitID:   currentCommit,
+						Downloaded: time.Now().Format(time.RFC3339),
+					})
+					return binaryPath, nil
+				}
 			}
-			fmt.Fprintf(os.Stderr, "Failed to download from public repository: %v\n", err)
 		}
 	}
 
-	return "", fmt.Errorf("failed to download device proxy binary")
+	// If no exact match or failed, try latest release
+	release, err := getLatestRelease(deviceProxyPublicRepo)
+	if err != nil {
+		return "", fmt.Errorf("failed to get latest release: %v", err)
+	}
+
+	// Check if we already have this version
+	if cachedInfo.TagName == release.TagName {
+		return binaryPath, nil
+	}
+
+	// Download latest version
+	assetURL, assetName, err := findDeviceProxyAssetForPlatform(release)
+	if err != nil {
+		return "", fmt.Errorf("failed to find device proxy asset: %v", err)
+	}
+
+	binaryPath, err = downloadAndExtractBinaryWithRetry(assetURL, assetName)
+	if err != nil {
+		return "", fmt.Errorf("failed to download device proxy: %v", err)
+	}
+
+	// Save version info
+	saveVersionInfo(&VersionInfo{
+		TagName:    release.TagName,
+		CommitID:   currentCommit,
+		Downloaded: time.Now().Format(time.RFC3339),
+	})
+
+	return binaryPath, nil
+}
+
+// DownloadDeviceProxy downloads the gbox-device-proxy binary from GitHub
+// It first tries to download from a release matching the current version,
+// and falls back to the latest release if no matching version is found
+func DownloadDeviceProxy() (string, error) {
+	currentVersion := version.ClientInfo()["Version"]
+	currentCommit := version.ClientInfo()["GitCommit"]
+
+	var release *GitHubRelease
+	var err error
+
+	// First try to find release matching current version
+	if currentVersion != "dev" {
+		release, err = getReleaseByTag(deviceProxyPublicRepo, currentVersion)
+		if err == nil {
+			// Found matching version, try to download from it
+			assetURL, assetName, err := findDeviceProxyAssetForPlatform(release)
+			if err == nil {
+				binaryPath, err := downloadAndExtractBinaryWithRetry(assetURL, assetName)
+				if err == nil {
+					// Save version info for matching version
+					saveVersionInfo(&VersionInfo{
+						TagName:    release.TagName,
+						CommitID:   currentCommit,
+						Downloaded: time.Now().Format(time.RFC3339),
+					})
+					return binaryPath, nil
+				}
+				// If download failed, continue to try latest release
+			}
+		}
+		// If no matching version found or download failed, continue to latest release
+	}
+
+	// Fallback to latest release
+	release, err = getLatestRelease(deviceProxyPublicRepo)
+	if err != nil {
+		return "", fmt.Errorf("failed to get latest release: %v", err)
+	}
+
+	assetURL, assetName, err := findDeviceProxyAssetForPlatform(release)
+	if err != nil {
+		return "", fmt.Errorf("failed to find device proxy asset: %v", err)
+	}
+
+	binaryPath, err := downloadAndExtractBinaryWithRetry(assetURL, assetName)
+	if err != nil {
+		return "", fmt.Errorf("failed to download device proxy: %v", err)
+	}
+
+	// Save version info for latest release
+	saveVersionInfo(&VersionInfo{
+		TagName:    release.TagName,
+		CommitID:   currentCommit,
+		Downloaded: time.Now().Format(time.RFC3339),
+	})
+
+	return binaryPath, nil
 }
 
 // getLatestRelease fetches the latest release from GitHub
-func getLatestRelease(repo, token string) (*GitHubRelease, error) {
+func getLatestRelease(repo string) (*GitHubRelease, error) {
 	url := fmt.Sprintf("%s/repos/%s/releases/latest", githubAPIURL, repo)
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -121,9 +290,37 @@ func getLatestRelease(repo, token string) (*GitHubRelease, error) {
 		return nil, err
 	}
 
-	if token != "" {
-		req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "gbox-cli")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned status: %d", resp.StatusCode)
+	}
+
+	var release GitHubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, err
+	}
+
+	return &release, nil
+}
+
+// getReleaseByTag fetches a specific release by tag from GitHub
+func getReleaseByTag(repo, tag string) (*GitHubRelease, error) {
+	url := fmt.Sprintf("%s/repos/%s/releases/tags/%s", githubAPIURL, repo, tag)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	req.Header.Set("User-Agent", "gbox-cli")
 
@@ -147,7 +344,7 @@ func getLatestRelease(repo, token string) (*GitHubRelease, error) {
 }
 
 // findDeviceProxyAssetForPlatform finds the device-proxy asset for the current platform
-func findDeviceProxyAssetForPlatform(release *GitHubRelease, token string) (string, string, error) {
+func findDeviceProxyAssetForPlatform(release *GitHubRelease) (string, string, error) {
 	osName := runtime.GOOS
 	arch := runtime.GOARCH
 
@@ -181,22 +378,13 @@ func findDeviceProxyAssetForPlatform(release *GitHubRelease, token string) (stri
 	// Find device-proxy asset containing the platform
 	for _, asset := range release.Assets {
 		if strings.Contains(asset.Name, "gbox-device-proxy") && strings.Contains(asset.Name, platform) {
-			// If unauthenticated, prefer browser_download_url; otherwise prefer API asset URL
-			if token == "" {
-				if asset.DownloadURL != "" {
-					return asset.DownloadURL, asset.Name, nil
-				}
-				// fallback to API URL even without token (may rate-limit/fail)
-				if asset.URL != "" {
-					return asset.URL, asset.Name, nil
-				}
-			} else {
-				if asset.URL != "" {
-					return asset.URL, asset.Name, nil
-				}
-				if asset.DownloadURL != "" {
-					return asset.DownloadURL, asset.Name, nil
-				}
+			// Use browser_download_url for public access
+			if asset.DownloadURL != "" {
+				return asset.DownloadURL, asset.Name, nil
+			}
+			// fallback to API URL (may rate-limit/fail)
+			if asset.URL != "" {
+				return asset.URL, asset.Name, nil
 			}
 		}
 	}
@@ -205,7 +393,7 @@ func findDeviceProxyAssetForPlatform(release *GitHubRelease, token string) (stri
 }
 
 // downloadAndExtractBinary downloads and extracts the binary file
-func downloadAndExtractBinary(assetURL, assetName, token string) (string, error) {
+func downloadAndExtractBinary(assetURL, assetName string) (string, error) {
 	// Get device proxy home directory first
 	deviceProxyHome := config.GetDeviceProxyHome()
 	if err := os.MkdirAll(deviceProxyHome, 0755); err != nil {
@@ -214,7 +402,7 @@ func downloadAndExtractBinary(assetURL, assetName, token string) (string, error)
 
 	// Download the asset directly to device proxy home directory
 	assetPath := filepath.Join(deviceProxyHome, assetName)
-	if err := downloadFile(assetURL, assetPath, token); err != nil {
+	if err := downloadFile(assetURL, assetPath); err != nil {
 		return "", err
 	}
 
@@ -265,12 +453,12 @@ func downloadAndExtractBinary(assetURL, assetName, token string) (string, error)
 }
 
 // downloadAndExtractBinaryWithRetry downloads and extracts the binary file with retry logic
-func downloadAndExtractBinaryWithRetry(assetURL, assetName, token string) (string, error) {
+func downloadAndExtractBinaryWithRetry(assetURL, assetName string) (string, error) {
 	var binaryPath string
 	var lastErr error
 	maxRetries := 3
 	for i := 0; i < maxRetries; i++ {
-		binaryPath, lastErr = downloadAndExtractBinary(assetURL, assetName, token)
+		binaryPath, lastErr = downloadAndExtractBinary(assetURL, assetName)
 		if lastErr == nil {
 			break
 		}
@@ -289,13 +477,12 @@ func downloadAndExtractBinaryWithRetry(assetURL, assetName, token string) (strin
 }
 
 // downloadFile downloads a file from URL to local path
-func downloadFile(url, filepath string, token string) error {
+func downloadFile(url, filepath string) error {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err
 	}
 
-	req.Header.Set("Authorization", "token "+token)
 	req.Header.Set("Accept", "application/octet-stream")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 

--- a/packages/cli/internal/device_connect/downloader_test.go
+++ b/packages/cli/internal/device_connect/downloader_test.go
@@ -2,7 +2,6 @@ package device_connect
 
 import (
 	"os"
-	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -52,81 +51,6 @@ func TestFindDeviceProxyAssetForPlatform(t *testing.T) {
 	}
 
 	t.Logf("Found asset: %s", assetName)
-}
-
-func TestDownloadSHA256File(t *testing.T) {
-	// First get a release and find an asset
-	release, err := getLatestRelease(deviceProxyPublicRepo)
-	if err != nil {
-		t.Fatalf("Failed to get latest release: %v", err)
-	}
-
-	_, assetName, err := findDeviceProxyAssetForPlatform(release)
-	if err != nil {
-		t.Fatalf("Failed to find device proxy asset: %v", err)
-	}
-
-	// Find the SHA256 file for this asset
-	sha256URL, err := findSHA256File(release, assetName)
-	if err != nil {
-		t.Skipf("SHA256 file not found for asset %s, skipping test: %v", assetName, err)
-	}
-
-	// Download and verify SHA256 file
-	sha256Hash, err := downloadSHA256File(sha256URL)
-	if err != nil {
-		t.Fatalf("Failed to download SHA256 file: %v", err)
-	}
-
-	if len(sha256Hash) != 64 {
-		t.Errorf("Expected SHA256 hash to be 64 characters, got %d: %s", len(sha256Hash), sha256Hash)
-	}
-
-	t.Logf("Downloaded SHA256: %s", sha256Hash)
-}
-
-func TestDownloadFile(t *testing.T) {
-	// Create a temporary directory for testing
-	tempDir, err := os.MkdirTemp("", "gbox-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	// Test downloading a small file (we'll use the SHA256 file as it's small)
-	release, err := getLatestRelease(deviceProxyPublicRepo)
-	if err != nil {
-		t.Fatalf("Failed to get latest release: %v", err)
-	}
-
-	_, assetName, err := findDeviceProxyAssetForPlatform(release)
-	if err != nil {
-		t.Fatalf("Failed to find device proxy asset: %v", err)
-	}
-
-	sha256URL, err := findSHA256File(release, assetName)
-	if err != nil {
-		t.Skipf("SHA256 file not found for asset %s, skipping test: %v", assetName, err)
-	}
-
-	// Download the SHA256 file
-	localPath := filepath.Join(tempDir, "test.sha256")
-	err = downloadFile(sha256URL, localPath)
-	if err != nil {
-		t.Fatalf("Failed to download file: %v", err)
-	}
-
-	// Verify the file was downloaded
-	info, err := os.Stat(localPath)
-	if err != nil {
-		t.Fatalf("Failed to stat downloaded file: %v", err)
-	}
-
-	if info.Size() == 0 {
-		t.Error("Downloaded file should not be empty")
-	}
-
-	t.Logf("Successfully downloaded file: %s (%d bytes)", localPath, info.Size())
 }
 
 func TestDownloadDeviceProxyIntegration(t *testing.T) {

--- a/packages/cli/internal/device_connect/downloader_test.go
+++ b/packages/cli/internal/device_connect/downloader_test.go
@@ -1,0 +1,417 @@
+package device_connect
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/babelcloud/gbox/packages/cli/config"
+	"github.com/babelcloud/gbox/packages/cli/internal/version"
+)
+
+func TestGetLatestRelease(t *testing.T) {
+	// Test getting latest release from public repository
+	release, err := getLatestRelease(deviceProxyPublicRepo)
+	if err != nil {
+		t.Fatalf("Failed to get latest release: %v", err)
+	}
+
+	if release.TagName == "" {
+		t.Error("Expected release to have a tag name")
+	}
+
+	if len(release.Assets) == 0 {
+		t.Error("Expected release to have assets")
+	}
+
+	t.Logf("Latest release: %s with %d assets", release.TagName, len(release.Assets))
+}
+
+func TestFindDeviceProxyAssetForPlatform(t *testing.T) {
+	// First get a release
+	release, err := getLatestRelease(deviceProxyPublicRepo)
+	if err != nil {
+		t.Fatalf("Failed to get latest release: %v", err)
+	}
+
+	// Test finding asset for current platform
+	_, assetName, err := findDeviceProxyAssetForPlatform(release)
+	if err != nil {
+		t.Fatalf("Failed to find device proxy asset: %v", err)
+	}
+
+	if assetName == "" {
+		t.Error("Expected asset name to be non-empty")
+	}
+
+	// Verify the asset name contains the expected platform
+	expectedPlatform := getExpectedPlatform()
+	if !contains(assetName, expectedPlatform) {
+		t.Errorf("Asset name '%s' should contain platform '%s'", assetName, expectedPlatform)
+	}
+
+	t.Logf("Found asset: %s", assetName)
+}
+
+func TestDownloadSHA256File(t *testing.T) {
+	// First get a release and find an asset
+	release, err := getLatestRelease(deviceProxyPublicRepo)
+	if err != nil {
+		t.Fatalf("Failed to get latest release: %v", err)
+	}
+
+	_, assetName, err := findDeviceProxyAssetForPlatform(release)
+	if err != nil {
+		t.Fatalf("Failed to find device proxy asset: %v", err)
+	}
+
+	// Find the SHA256 file for this asset
+	sha256URL, err := findSHA256File(release, assetName)
+	if err != nil {
+		t.Skipf("SHA256 file not found for asset %s, skipping test: %v", assetName, err)
+	}
+
+	// Download and verify SHA256 file
+	sha256Hash, err := downloadSHA256File(sha256URL)
+	if err != nil {
+		t.Fatalf("Failed to download SHA256 file: %v", err)
+	}
+
+	if len(sha256Hash) != 64 {
+		t.Errorf("Expected SHA256 hash to be 64 characters, got %d: %s", len(sha256Hash), sha256Hash)
+	}
+
+	t.Logf("Downloaded SHA256: %s", sha256Hash)
+}
+
+func TestDownloadFile(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "gbox-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Test downloading a small file (we'll use the SHA256 file as it's small)
+	release, err := getLatestRelease(deviceProxyPublicRepo)
+	if err != nil {
+		t.Fatalf("Failed to get latest release: %v", err)
+	}
+
+	_, assetName, err := findDeviceProxyAssetForPlatform(release)
+	if err != nil {
+		t.Fatalf("Failed to find device proxy asset: %v", err)
+	}
+
+	sha256URL, err := findSHA256File(release, assetName)
+	if err != nil {
+		t.Skipf("SHA256 file not found for asset %s, skipping test: %v", assetName, err)
+	}
+
+	// Download the SHA256 file
+	localPath := filepath.Join(tempDir, "test.sha256")
+	err = downloadFile(sha256URL, localPath)
+	if err != nil {
+		t.Fatalf("Failed to download file: %v", err)
+	}
+
+	// Verify the file was downloaded
+	info, err := os.Stat(localPath)
+	if err != nil {
+		t.Fatalf("Failed to stat downloaded file: %v", err)
+	}
+
+	if info.Size() == 0 {
+		t.Error("Downloaded file should not be empty")
+	}
+
+	t.Logf("Successfully downloaded file: %s (%d bytes)", localPath, info.Size())
+}
+
+func TestDownloadDeviceProxyIntegration(t *testing.T) {
+	// This is an integration test that actually downloads the binary
+	// Skip in CI environments to avoid rate limiting
+	if os.Getenv("CI") == "true" {
+		t.Skip("Skipping integration test in CI environment")
+	}
+
+	// Test the full download process
+	binaryPath, err := DownloadDeviceProxy()
+	if err != nil {
+		t.Fatalf("Failed to download device proxy: %v", err)
+	}
+
+	// Verify the binary exists and is executable
+	info, err := os.Stat(binaryPath)
+	if err != nil {
+		t.Fatalf("Failed to stat downloaded binary: %v", err)
+	}
+
+	if info.IsDir() {
+		t.Error("Downloaded binary should not be a directory")
+	}
+
+	// Check if it's executable (on Unix systems)
+	if runtime.GOOS != "windows" {
+		mode := info.Mode()
+		if mode&0111 == 0 {
+			t.Error("Downloaded binary should be executable")
+		}
+	}
+
+	// Verify version cache was created
+	cachePath := getVersionCachePath()
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Errorf("Version cache file should exist: %v", err)
+	}
+
+	// Load and verify version info
+	versionInfo, err := loadVersionInfo()
+	if err != nil {
+		t.Fatalf("Failed to load version info: %v", err)
+	}
+
+	if versionInfo.TagName == "" {
+		t.Error("Version info should have a tag name")
+	}
+
+	t.Logf("Successfully downloaded device proxy binary: %s (%d bytes)", binaryPath, info.Size())
+	t.Logf("Downloaded from version: %s", versionInfo.TagName)
+}
+
+func TestCheckAndDownloadDeviceProxy(t *testing.T) {
+	// This test verifies the version-aware download functionality
+	// Skip in CI environments to avoid rate limiting
+	if os.Getenv("CI") == "true" {
+		t.Skip("Skipping integration test in CI environment")
+	}
+
+	// Test the version-aware download process
+	binaryPath, err := CheckAndDownloadDeviceProxy()
+	if err != nil {
+		t.Fatalf("Failed to check and download device proxy: %v", err)
+	}
+
+	// Verify the binary exists
+	info, err := os.Stat(binaryPath)
+	if err != nil {
+		t.Fatalf("Failed to stat downloaded binary: %v", err)
+	}
+
+	if info.IsDir() {
+		t.Error("Downloaded binary should not be a directory")
+	}
+
+	// Verify version cache was created
+	cachePath := getVersionCachePath()
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Errorf("Version cache file should exist: %v", err)
+	}
+
+	// Load and verify version info
+	versionInfo, err := loadVersionInfo()
+	if err != nil {
+		t.Fatalf("Failed to load version info: %v", err)
+	}
+
+	if versionInfo.TagName == "" {
+		t.Error("Version info should have a tag name")
+	}
+
+	if versionInfo.Downloaded == "" {
+		t.Error("Version info should have a download timestamp")
+	}
+
+	t.Logf("Successfully checked and downloaded device proxy binary: %s", binaryPath)
+	t.Logf("Version info: %+v", versionInfo)
+}
+
+func TestVersionCache(t *testing.T) {
+	// Test version cache functionality
+	tempDir, err := os.MkdirTemp("", "gbox-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Temporarily override device proxy home for testing
+	originalHome := config.GetDeviceProxyHome()
+	defer func() {
+		// Restore original home
+		os.Setenv("DEVICE_PROXY_HOME", originalHome)
+	}()
+
+	os.Setenv("DEVICE_PROXY_HOME", tempDir)
+
+	// Test saving and loading version info
+	testInfo := &VersionInfo{
+		TagName:    "v1.0.0",
+		CommitID:   "abc123",
+		Downloaded: "2023-01-01T00:00:00Z",
+	}
+
+	err = saveVersionInfo(testInfo)
+	if err != nil {
+		t.Fatalf("Failed to save version info: %v", err)
+	}
+
+	loadedInfo, err := loadVersionInfo()
+	if err != nil {
+		t.Fatalf("Failed to load version info: %v", err)
+	}
+
+	if loadedInfo.TagName != testInfo.TagName {
+		t.Errorf("Expected tag name %s, got %s", testInfo.TagName, loadedInfo.TagName)
+	}
+
+	if loadedInfo.CommitID != testInfo.CommitID {
+		t.Errorf("Expected commit ID %s, got %s", testInfo.CommitID, loadedInfo.CommitID)
+	}
+
+	if loadedInfo.Downloaded != testInfo.Downloaded {
+		t.Errorf("Expected downloaded time %s, got %s", testInfo.Downloaded, loadedInfo.Downloaded)
+	}
+
+	t.Logf("Version cache test passed")
+}
+
+func TestGetReleaseByTag(t *testing.T) {
+	// Test getting a specific release by tag
+	// Use a known tag that exists
+	release, err := getReleaseByTag(deviceProxyPublicRepo, "v0.1.7")
+	if err != nil {
+		t.Fatalf("Failed to get release by tag: %v", err)
+	}
+
+	if release.TagName != "v0.1.7" {
+		t.Errorf("Expected tag name v0.1.7, got %s", release.TagName)
+	}
+
+	if len(release.Assets) == 0 {
+		t.Error("Expected release to have assets")
+	}
+
+	t.Logf("Successfully got release by tag: %s with %d assets", release.TagName, len(release.Assets))
+}
+
+func TestDownloadDeviceProxyVersionMatching(t *testing.T) {
+	// This test verifies that DownloadDeviceProxy tries to match current version first
+	// Skip in CI environments to avoid rate limiting
+	if os.Getenv("CI") == "true" {
+		t.Skip("Skipping integration test in CI environment")
+	}
+
+	// Get current version info
+	clientInfo := version.ClientInfo()
+	currentVersion := clientInfo["Version"]
+
+	t.Logf("Current CLI version: %s", currentVersion)
+
+	// Test the download process
+	binaryPath, err := DownloadDeviceProxy()
+	if err != nil {
+		t.Fatalf("Failed to download device proxy: %v", err)
+	}
+
+	// Verify the binary exists
+	info, err := os.Stat(binaryPath)
+	if err != nil {
+		t.Fatalf("Failed to stat downloaded binary: %v", err)
+	}
+
+	if info.IsDir() {
+		t.Error("Downloaded binary should not be a directory")
+	}
+
+	// Load version info to see which version was actually downloaded
+	versionInfo, err := loadVersionInfo()
+	if err != nil {
+		t.Fatalf("Failed to load version info: %v", err)
+	}
+
+	t.Logf("Downloaded binary from version: %s", versionInfo.TagName)
+	t.Logf("Binary size: %d bytes", info.Size())
+
+	// If current version is not "dev", we should try to match it
+	if currentVersion != "dev" {
+		t.Logf("Current version is %s, checking if we tried to match it", currentVersion)
+		// Note: We can't easily verify which version was attempted first in this test
+		// but we can verify that the download succeeded and version info was saved
+	}
+
+	t.Logf("Download completed successfully")
+}
+
+// Helper functions
+
+func getExpectedPlatform() string {
+	osName := runtime.GOOS
+	arch := runtime.GOARCH
+
+	switch osName {
+	case "darwin":
+		if arch == "amd64" {
+			return "darwin-amd64"
+		} else if arch == "arm64" {
+			return "darwin-arm64"
+		}
+	case "linux":
+		if arch == "amd64" {
+			return "linux-amd64"
+		} else if arch == "arm64" {
+			return "linux-arm64"
+		}
+	case "windows":
+		if arch == "amd64" {
+			return "windows-amd64"
+		} else if arch == "arm64" {
+			return "windows-arm64"
+		}
+	}
+
+	return ""
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr ||
+		(len(s) > len(substr) &&
+			(s[:len(substr)] == substr ||
+				s[len(s)-len(substr):] == substr ||
+				containsSubstring(s, substr))))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// Benchmark tests
+
+func BenchmarkGetLatestRelease(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := getLatestRelease(deviceProxyPublicRepo)
+		if err != nil {
+			b.Fatalf("Failed to get latest release: %v", err)
+		}
+	}
+}
+
+func BenchmarkFindDeviceProxyAssetForPlatform(b *testing.B) {
+	release, err := getLatestRelease(deviceProxyPublicRepo)
+	if err != nil {
+		b.Fatalf("Failed to get latest release: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, err := findDeviceProxyAssetForPlatform(release)
+		if err != nil {
+			b.Fatalf("Failed to find device proxy asset: %v", err)
+		}
+	}
+}

--- a/packages/cli/internal/device_connect/version_test.go
+++ b/packages/cli/internal/device_connect/version_test.go
@@ -1,0 +1,384 @@
+package device_connect
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/babelcloud/gbox/packages/cli/config"
+)
+
+func TestVersionMatchingLogic(t *testing.T) {
+	// Test the version matching logic with different scenarios
+	tempDir, err := os.MkdirTemp("", "gbox-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Temporarily override device proxy home for testing
+	originalHome := config.GetDeviceProxyHome()
+	defer func() {
+		os.Setenv("DEVICE_PROXY_HOME", originalHome)
+	}()
+
+	os.Setenv("DEVICE_PROXY_HOME", tempDir)
+
+	// Test scenario 1: No binary exists - should download latest
+	t.Run("NoBinaryExists", func(t *testing.T) {
+		// Ensure no binary exists
+		binaryName := "gbox-device-proxy"
+		if runtime.GOOS == "windows" {
+			binaryName += ".exe"
+		}
+		binaryPath := filepath.Join(tempDir, binaryName)
+		os.Remove(binaryPath)
+		os.Remove(getVersionCachePath())
+
+		// Should download latest
+		path, err := CheckAndDownloadDeviceProxy()
+		if err != nil {
+			t.Fatalf("Failed to download when no binary exists: %v", err)
+		}
+
+		if path != binaryPath {
+			t.Errorf("Expected binary path %s, got %s", binaryPath, path)
+		}
+
+		// Verify version cache was created
+		if _, err := os.Stat(getVersionCachePath()); err != nil {
+			t.Errorf("Version cache should exist: %v", err)
+		}
+	})
+
+	// Test scenario 2: Binary exists with matching version - should not download
+	t.Run("BinaryExistsWithMatchingVersion", func(t *testing.T) {
+		// Create a fake binary
+		binaryName := "gbox-device-proxy"
+		if runtime.GOOS == "windows" {
+			binaryName += ".exe"
+		}
+		binaryPath := filepath.Join(tempDir, binaryName)
+		if err := os.WriteFile(binaryPath, []byte("fake binary"), 0755); err != nil {
+			t.Fatalf("Failed to create fake binary: %v", err)
+		}
+
+		// Create version cache with current latest version
+		latestRelease, err := getLatestRelease(deviceProxyPublicRepo)
+		if err != nil {
+			t.Fatalf("Failed to get latest release: %v", err)
+		}
+
+		cacheInfo := &VersionInfo{
+			TagName:    latestRelease.TagName,
+			CommitID:   "test-commit",
+			Downloaded: time.Now().Format(time.RFC3339),
+		}
+		if err := saveVersionInfo(cacheInfo); err != nil {
+			t.Fatalf("Failed to save version info: %v", err)
+		}
+
+		// Should return existing binary without downloading
+		path, err := CheckAndDownloadDeviceProxy()
+		if err != nil {
+			t.Fatalf("Failed to check version: %v", err)
+		}
+
+		if path != binaryPath {
+			t.Errorf("Expected binary path %s, got %s", binaryPath, path)
+		}
+
+		// Verify the binary wasn't replaced (content should still be "fake binary")
+		content, err := os.ReadFile(binaryPath)
+		if err != nil {
+			t.Fatalf("Failed to read binary: %v", err)
+		}
+
+		if string(content) != "fake binary" {
+			t.Error("Binary should not have been replaced")
+		}
+	})
+
+	// Test scenario 3: Binary exists with different version - should download
+	t.Run("BinaryExistsWithDifferentVersion", func(t *testing.T) {
+		// Create a fake binary
+		binaryName := "gbox-device-proxy"
+		if runtime.GOOS == "windows" {
+			binaryName += ".exe"
+		}
+		binaryPath := filepath.Join(tempDir, binaryName)
+		if err := os.WriteFile(binaryPath, []byte("old fake binary"), 0755); err != nil {
+			t.Fatalf("Failed to create fake binary: %v", err)
+		}
+
+		// Create version cache with old version
+		cacheInfo := &VersionInfo{
+			TagName:    "v0.0.1", // Old version
+			CommitID:   "old-commit",
+			Downloaded: time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
+		}
+		if err := saveVersionInfo(cacheInfo); err != nil {
+			t.Fatalf("Failed to save version info: %v", err)
+		}
+
+		// Should download new version
+		path, err := CheckAndDownloadDeviceProxy()
+		if err != nil {
+			t.Fatalf("Failed to check version: %v", err)
+		}
+
+		if path != binaryPath {
+			t.Errorf("Expected binary path %s, got %s", binaryPath, path)
+		}
+
+		// Verify the binary was replaced (should be a real binary now)
+		info, err := os.Stat(binaryPath)
+		if err != nil {
+			t.Fatalf("Failed to stat binary: %v", err)
+		}
+
+		if info.Size() < 1000 { // Real binary should be much larger
+			t.Error("Binary should have been replaced with real binary")
+		}
+
+		// Verify version cache was updated
+		newCacheInfo, err := loadVersionInfo()
+		if err != nil {
+			t.Fatalf("Failed to load version info: %v", err)
+		}
+
+		if newCacheInfo.TagName == "v0.0.1" {
+			t.Error("Version cache should have been updated")
+		}
+	})
+}
+
+func TestVersionCacheOperations(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "gbox-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Temporarily override device proxy home for testing
+	originalHome := config.GetDeviceProxyHome()
+	defer func() {
+		os.Setenv("DEVICE_PROXY_HOME", originalHome)
+	}()
+
+	os.Setenv("DEVICE_PROXY_HOME", tempDir)
+
+	// Test saving version info
+	t.Run("SaveVersionInfo", func(t *testing.T) {
+		testInfo := &VersionInfo{
+			TagName:    "v1.2.3",
+			CommitID:   "abc123def456",
+			Downloaded: "2023-12-01T10:30:00Z",
+		}
+
+		err := saveVersionInfo(testInfo)
+		if err != nil {
+			t.Fatalf("Failed to save version info: %v", err)
+		}
+
+		// Verify file was created
+		cachePath := getVersionCachePath()
+		if _, err := os.Stat(cachePath); err != nil {
+			t.Errorf("Version cache file should exist: %v", err)
+		}
+
+		// Verify content
+		data, err := os.ReadFile(cachePath)
+		if err != nil {
+			t.Fatalf("Failed to read cache file: %v", err)
+		}
+
+		if !contains(string(data), "v1.2.3") {
+			t.Error("Cache file should contain version v1.2.3")
+		}
+
+		if !contains(string(data), "abc123def456") {
+			t.Error("Cache file should contain commit ID")
+		}
+	})
+
+	// Test loading version info
+	t.Run("LoadVersionInfo", func(t *testing.T) {
+		// First save some data
+		testInfo := &VersionInfo{
+			TagName:    "v2.0.0",
+			CommitID:   "xyz789",
+			Downloaded: "2023-12-02T15:45:00Z",
+		}
+
+		if err := saveVersionInfo(testInfo); err != nil {
+			t.Fatalf("Failed to save version info: %v", err)
+		}
+
+		// Then load it
+		loadedInfo, err := loadVersionInfo()
+		if err != nil {
+			t.Fatalf("Failed to load version info: %v", err)
+		}
+
+		if loadedInfo.TagName != testInfo.TagName {
+			t.Errorf("Expected tag name %s, got %s", testInfo.TagName, loadedInfo.TagName)
+		}
+
+		if loadedInfo.CommitID != testInfo.CommitID {
+			t.Errorf("Expected commit ID %s, got %s", testInfo.CommitID, loadedInfo.CommitID)
+		}
+
+		if loadedInfo.Downloaded != testInfo.Downloaded {
+			t.Errorf("Expected downloaded time %s, got %s", testInfo.Downloaded, loadedInfo.Downloaded)
+		}
+	})
+
+	// Test loading non-existent file
+	t.Run("LoadNonExistentFile", func(t *testing.T) {
+		// Remove cache file
+		os.Remove(getVersionCachePath())
+
+		// Try to load
+		_, err := loadVersionInfo()
+		if err == nil {
+			t.Error("Expected error when loading non-existent file")
+		}
+	})
+}
+
+func TestGetReleaseByTagErrorHandling(t *testing.T) {
+	// Test getting a non-existent tag
+	t.Run("NonExistentTag", func(t *testing.T) {
+		_, err := getReleaseByTag(deviceProxyPublicRepo, "v999.999.999")
+		if err == nil {
+			t.Error("Expected error when getting non-existent tag")
+		}
+	})
+
+	// Test getting a valid tag
+	t.Run("ValidTag", func(t *testing.T) {
+		release, err := getReleaseByTag(deviceProxyPublicRepo, "v0.1.7")
+		if err != nil {
+			t.Fatalf("Failed to get valid tag: %v", err)
+		}
+
+		if release.TagName != "v0.1.7" {
+			t.Errorf("Expected tag name v0.1.7, got %s", release.TagName)
+		}
+	})
+}
+
+func TestVersionMatchingPriority(t *testing.T) {
+	// This test verifies the version matching priority logic
+	tempDir, err := os.MkdirTemp("", "gbox-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Temporarily override device proxy home for testing
+	originalHome := config.GetDeviceProxyHome()
+	defer func() {
+		os.Setenv("DEVICE_PROXY_HOME", originalHome)
+	}()
+
+	os.Setenv("DEVICE_PROXY_HOME", tempDir)
+
+	// Test scenario: Current version is "dev" - should download latest
+	t.Run("DevVersionDownloadsLatest", func(t *testing.T) {
+		// Remove any existing binary and cache
+		binaryName := "gbox-device-proxy"
+		if runtime.GOOS == "windows" {
+			binaryName += ".exe"
+		}
+		binaryPath := filepath.Join(tempDir, binaryName)
+		os.Remove(binaryPath)
+		os.Remove(getVersionCachePath())
+
+		// Download with "dev" version (current test environment)
+		binaryPath, err := DownloadDeviceProxy()
+		if err != nil {
+			// Check if it's a rate limit error and skip the test
+			if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "rate limit") {
+				t.Skip("GitHub API rate limit reached, skipping download test")
+			}
+			t.Fatalf("Failed to download device proxy: %v", err)
+		}
+
+		// Verify binary was downloaded
+		if _, err := os.Stat(binaryPath); err != nil {
+			t.Fatalf("Binary should exist: %v", err)
+		}
+
+		// Verify version cache was created
+		versionInfo, err := loadVersionInfo()
+		if err != nil {
+			t.Fatalf("Failed to load version info: %v", err)
+		}
+
+		// Should have downloaded from latest release
+		if versionInfo.TagName == "" {
+			t.Error("Version info should have a tag name")
+		}
+
+		t.Logf("Downloaded from version: %s", versionInfo.TagName)
+	})
+
+	// Test scenario: Current version matches existing release
+	t.Run("MatchingVersionDownloadsFromRelease", func(t *testing.T) {
+		// Remove any existing binary and cache
+		binaryName := "gbox-device-proxy"
+		if runtime.GOOS == "windows" {
+			binaryName += ".exe"
+		}
+		binaryPath := filepath.Join(tempDir, binaryName)
+		os.Remove(binaryPath)
+		os.Remove(getVersionCachePath())
+
+		// Create a fake binary to simulate existing installation
+		if err := os.WriteFile(binaryPath, []byte("fake binary"), 0755); err != nil {
+			t.Fatalf("Failed to create fake binary: %v", err)
+		}
+
+		// Create version cache with a specific version that exists
+		cacheInfo := &VersionInfo{
+			TagName:    "v0.1.7",
+			CommitID:   "test-commit",
+			Downloaded: time.Now().Format(time.RFC3339),
+		}
+		if err := saveVersionInfo(cacheInfo); err != nil {
+			t.Fatalf("Failed to save version info: %v", err)
+		}
+
+		// Use CheckAndDownloadDeviceProxy which should respect the cached version
+		newBinaryPath, err := CheckAndDownloadDeviceProxy()
+		if err != nil {
+			// Check if it's a rate limit error and skip the test
+			if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "rate limit") {
+				t.Skip("GitHub API rate limit reached, skipping download test")
+			}
+			t.Fatalf("Failed to check and download device proxy: %v", err)
+		}
+
+		// Should return existing binary path
+		if newBinaryPath != binaryPath {
+			t.Errorf("Expected binary path %s, got %s", binaryPath, newBinaryPath)
+		}
+
+		// Verify the binary wasn't replaced (content should still be "fake binary")
+		content, err := os.ReadFile(binaryPath)
+		if err != nil {
+			t.Fatalf("Failed to read binary: %v", err)
+		}
+
+		if string(content) != "fake binary" {
+			t.Error("Binary should not have been replaced")
+		}
+
+		t.Logf("Successfully used cached version without downloading")
+	})
+}


### PR DESCRIPTION
Eliminate GitHub token from configuration and related functions. Update Makefile to reflect changes in build flags. Simplify the downloader logic by removing token dependency for downloading device proxy binaries.