### PR TITLE
:rotating_light: refactor: update profile access methods to use Default instance

### DIFF
--- a/packages/cli/cmd/adb_expose_start.go
+++ b/packages/cli/cmd/adb_expose_start.go
@@ -56,7 +56,7 @@ func ExecuteAdbExpose(cmd *cobra.Command, opts *AdbExposeOptions, args []string)
 	remotePort := 5555
 
 	// Get API Key with priority: GBOX_API_KEY env var > profile
-	apiKey, err := profile.GetEffectiveAPIKey()
+	apiKey, err := profile.Default.GetEffectiveAPIKey()
 	if err != nil {
 		return fmt.Errorf("failed to get API key: %v", err)
 	}
@@ -88,7 +88,7 @@ func ExecuteAdbExpose(cmd *cobra.Command, opts *AdbExposeOptions, args []string)
 	}()
 
 	// Get effective base URL for connection
-	effectiveBaseURL := profile.GetEffectiveBaseURL()
+	effectiveBaseURL := profile.Default.GetEffectiveBaseURL()
 
 	// Connect to websocket
 	portForwardConfig := adb_expose.Config{

--- a/packages/cli/cmd/box_cp.go
+++ b/packages/cli/cmd/box_cp.go
@@ -99,7 +99,7 @@ func runCopyCommand(opts *BoxCpOptions) error {
 	debugEnabled := os.Getenv("DEBUG") == "true"
 
 	// Get effective base URL for API calls
-	effectiveBaseURL := profile.GetEffectiveBaseURL()
+	effectiveBaseURL := profile.Default.GetEffectiveBaseURL()
 	apiURL := fmt.Sprintf("%s/api/v1", effectiveBaseURL)
 
 	// Debug log

--- a/packages/cli/cmd/box_exec.go
+++ b/packages/cli/cmd/box_exec.go
@@ -104,7 +104,7 @@ func runExecWebSocket(opts *BoxExecOptions, resolvedBoxID string) error {
 		// handle error, maybe default to cloud
 	}
 	// Get effective base URL from profile with priority: GBOX_BASE_URL > profile > default
-	effectiveBaseURL := profile.GetEffectiveBaseURL()
+	effectiveBaseURL := profile.Default.GetEffectiveBaseURL()
 	apiBase := effectiveBaseURL
 
 	// convert http(s):// to ws(s)://

--- a/packages/cli/internal/client/client.go
+++ b/packages/cli/internal/client/client.go
@@ -40,7 +40,7 @@ type profileEntry struct {
 // created without an API key.
 func NewClientFromProfile() (*sdk.Client, error) {
 	// Get effective base URL with proper priority handling
-	baseURL := profile.GetEffectiveBaseURL()
+	baseURL := profile.Default.GetEffectiveBaseURL()
 
 	// Get profile file path from config
 	profilePath := config.GetProfilePath()

--- a/packages/cli/internal/cloud/client.go
+++ b/packages/cli/internal/cloud/client.go
@@ -51,7 +51,7 @@ func NewClient(token string) (*Client, error) {
 	}
 
 	// Get base URL with proper priority handling
-	baseURL := profile.GetEffectiveBaseURL()
+	baseURL := profile.Default.GetEffectiveBaseURL()
 
 	return &Client{
 		httpClient: &http.Client{},

--- a/packages/cli/internal/device_connect/daemon_unix.go
+++ b/packages/cli/internal/device_connect/daemon_unix.go
@@ -38,13 +38,13 @@ func StartDeviceProxyService() error {
 	pidFile := filepath.Join(deviceProxyHome, "device-proxy.pid")
 
 	// Get API key from current profile
-	apiKey, err := profile.GetEffectiveAPIKey()
+	apiKey, err := profile.Default.GetEffectiveAPIKey()
 	if err != nil {
 		return fmt.Errorf("failed to get API key: %v", err)
 	}
 
 	// Get base URL from profile
-	baseURL := profile.GetEffectiveBaseURL()
+	baseURL := profile.Default.GetEffectiveBaseURL()
 
 	// Set up environment variables
 	env := setupDeviceProxyEnvironment(apiKey, baseURL)

--- a/packages/cli/internal/device_connect/daemon_windows.go
+++ b/packages/cli/internal/device_connect/daemon_windows.go
@@ -38,13 +38,13 @@ func StartDeviceProxyService() error {
 	pidFile := filepath.Join(deviceProxyHome, "device-proxy.pid")
 
 	// Get API key from current profile
-	apiKey, err := profile.GetEffectiveAPIKey()
+	apiKey, err := profile.Default.GetEffectiveAPIKey()
 	if err != nil {
 		return fmt.Errorf("failed to get API key: %v", err)
 	}
 
 	// Get base URL from profile
-	baseURL := profile.GetEffectiveBaseURL()
+	baseURL := profile.Default.GetEffectiveBaseURL()
 
 	// Set up environment variables
 	env := setupDeviceProxyEnvironment(apiKey, baseURL)


### PR DESCRIPTION
- Change API key and base URL retrieval methods to utilize the Default instance of the profile manager.
- Ensure consistent access to the effective API key and base URL, improving code maintainability and clarity.